### PR TITLE
Stream resource usage updates through Tauri events instead of websockets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -734,22 +734,36 @@
       }
     },
     "node_modules/@babel/helper-environment-visitor": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.5.tgz",
-      "integrity": "sha512-XGmhECfVA/5sAt+H+xpSg0mfrHq6FzNr9Oxh7PSEBBRUb/mL7Kz3NICXb194rCqAEdxkhPT1a88teizAFyvk8Q==",
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
+      "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-function-name": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.22.5.tgz",
-      "integrity": "sha512-wtHSq6jMRE3uF2otvfuD3DIvVhOsSNshQl0Qrd7qC9oQJzHvOL4qQXlQn2916+CXGywIjpGuIkoyZRRxHPiNQQ==",
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
+      "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
       "dev": true,
       "dependencies": {
-        "@babel/template": "^7.22.5",
-        "@babel/types": "^7.22.5"
+        "@babel/template": "^7.22.15",
+        "@babel/types": "^7.23.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-function-name/node_modules/@babel/template": {
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
+      "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.22.13",
+        "@babel/parser": "^7.22.15",
+        "@babel/types": "^7.22.15"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -911,9 +925,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.15.tgz",
-      "integrity": "sha512-4E/F9IIEi8WR94324mbDUMo074YTheJmd7eZF5vITTeYchqAi6sYXRLHUVsmkdmY4QjfKTcB2jB7dVP3NaBElQ==",
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -999,9 +1013,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.22.16",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.16.tgz",
-      "integrity": "sha512-+gPfKv8UWeKKeJTUxe59+OobVcrYHETCsORl61EmSkmgymguYk/X5bp7GuUIXaFsc6y++v8ZxPsLSSuujqDphA==",
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
+      "integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -2278,19 +2292,19 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.22.17",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.17.tgz",
-      "integrity": "sha512-xK4Uwm0JnAMvxYZxOVecss85WxTEIbTa7bnGyf/+EgCL5Zt3U7htUpEOWv9detPlamGKuRzCqw74xVglDWpPdg==",
+      "version": "7.23.2",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
+      "integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.22.13",
-        "@babel/generator": "^7.22.15",
-        "@babel/helper-environment-visitor": "^7.22.5",
-        "@babel/helper-function-name": "^7.22.5",
+        "@babel/generator": "^7.23.0",
+        "@babel/helper-environment-visitor": "^7.22.20",
+        "@babel/helper-function-name": "^7.23.0",
         "@babel/helper-hoist-variables": "^7.22.5",
         "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.22.16",
-        "@babel/types": "^7.22.17",
+        "@babel/parser": "^7.23.0",
+        "@babel/types": "^7.23.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -2299,12 +2313,12 @@
       }
     },
     "node_modules/@babel/traverse/node_modules/@babel/generator": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.15.tgz",
-      "integrity": "sha512-Zu9oWARBqeVOW0dZOjXc3JObrzuqothQ3y/n1kUtrjCoCPLkXUwMvOo/F/TCfoHMbWIFlWwpZtkZVb9ga4U2pA==",
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.0.tgz",
+      "integrity": "sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.22.15",
+        "@babel/types": "^7.23.0",
         "@jridgewell/gen-mapping": "^0.3.2",
         "@jridgewell/trace-mapping": "^0.3.17",
         "jsesc": "^2.5.1"
@@ -2314,13 +2328,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.22.17",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.17.tgz",
-      "integrity": "sha512-YSQPHLFtQNE5xN9tHuZnzu8vPr61wVTBZdfv1meex1NBosa4iT05k/Jw06ddJugi4bk7The/oSwQGFcksmEJQg==",
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
+      "integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
       "dev": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.22.5",
-        "@babel/helper-validator-identifier": "^7.22.15",
+        "@babel/helper-validator-identifier": "^7.22.20",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {

--- a/src-tauri/src/events/cpu.rs
+++ b/src-tauri/src/events/cpu.rs
@@ -1,0 +1,230 @@
+use std::{
+    collections::HashMap,
+    ops::{Deref, DerefMut},
+    sync::{Arc, Mutex},
+};
+
+use serde::Serialize;
+use sysinfo::{CpuExt, System, SystemExt};
+use tauri::{State, Window};
+
+use crate::systracker::cpu::{CoreBuffer, CpuTracker};
+
+use super::{
+    check_counter, get_counter_mutex_from_state, increment_counter_and_check, StreamEvent,
+    StreamEventAction,
+};
+
+/// Try to start emitting cpu historical data updates.
+/// If the event is already being emmited it does nothing but to
+/// increment its listeners counter.
+/// When the counter is set to 0 the thread will stop executing
+#[tauri::command]
+pub fn emit_cpu_mulitcore_historical_usage(
+    window: Window,
+    state: State<Arc<Mutex<CpuTracker>>>,
+    counters_state: State<Arc<HashMap<StreamEvent, Mutex<u8>>>>,
+) {
+    let stream_event_kind = StreamEvent::CpuMulticoreHistoricalUsage;
+    let tracker = Arc::clone(state.inner());
+    let listeners_count = Arc::clone(counters_state.inner());
+    let counter_mutex = get_counter_mutex_from_state(&stream_event_kind, counters_state);
+    match increment_counter_and_check(counter_mutex) {
+        StreamEventAction::StartStream => (),
+        _ => return,
+    }
+    println!("start emitting cpu multicore");
+    std::thread::spawn(move || {
+        loop {
+            //window.emit("cpu_multicore_updated", Payload { message: "Tauri is awesome!".into() }).unwrap();
+            let tracker = tracker.deref();
+            let data: Option<Vec<CoreBuffer>> = {
+                let mut tracker = match tracker.lock() {
+                    Ok(t) => t,
+                    Err(_) => continue,
+                };
+                let tracker = tracker.deref_mut();
+                tracker.fetch_usage()
+            };
+            window
+                .emit(stream_event_kind.as_str(), data.unwrap())
+                .unwrap();
+
+            // get the current counter mutex
+            let counter_mutex = {
+                listeners_count.get(&stream_event_kind).unwrap() // Should never panic if a counter for each variant (key) was inserted when created
+            };
+            //if there's no component listenig anymore we end this thread by breaking the loop
+            match check_counter(counter_mutex) {
+                StreamEventAction::StopStream => break,
+                _ => (),
+            }
+
+            //TODO: calc time elapsed
+            std::thread::sleep(std::time::Duration::from_millis(500));
+        }
+        println!("Stop emitting cpu multicore ");
+    });
+}
+
+/// Try to stop emitting CPU historical data updates by decreasing the counter
+#[tauri::command]
+pub fn stop_cpu_mulitcore_historical_usage(
+    counters_state: State<Arc<HashMap<StreamEvent, Mutex<u8>>>>,
+) {
+    let mut counter = counters_state
+        .inner()
+        .get(&StreamEvent::CpuMulticoreHistoricalUsage)
+        .unwrap() // Should never panic if a counter for each variant (key) was inserted when created
+        .lock()
+        .unwrap();
+    let counter = counter.deref_mut();
+    *counter = *counter - 1u8;
+}
+
+/// Try to start emitting cpu current usage updates
+/// If the event is already being emmited it does nothing but to
+/// increment the counter.
+/// When the counter is set to 0 the thread will stop executing
+#[tauri::command]
+pub fn emit_cpu_singlecore_current_usage(
+    window: Window,
+    counters_state: State<Arc<HashMap<StreamEvent, Mutex<u8>>>>,
+) {
+    let stream_event_kind = StreamEvent::CpuSinglecoreCurrentUsage;
+    let listeners_count = Arc::clone(counters_state.inner());
+    let counter_mutex = get_counter_mutex_from_state(&stream_event_kind, counters_state);
+    match increment_counter_and_check(counter_mutex) {
+        StreamEventAction::StartStream => (),
+        _ => return,
+    }
+    std::thread::spawn(move || {
+        let mut sys = System::new_all();
+        loop {
+            sys.refresh_cpu();
+            let mut data = 0f32;
+            for cpu in sys.cpus() {
+                data += cpu.cpu_usage();
+            }
+            data = data / sys.cpus().len() as f32;
+            window
+                .emit(stream_event_kind.as_str(), data)
+                .unwrap();
+
+            // get the current counter mutex
+            let counter_mutex = {
+                listeners_count.get(&stream_event_kind).unwrap() // Should never panic if a counter for each variant (key) was inserted when created
+            };
+            //if there's no component listenig anymore we end this thread by breaking the loop
+            match check_counter(counter_mutex) {
+                StreamEventAction::StopStream => break,
+                _ => (),
+            }
+            //TODO: calc time elapsed
+            std::thread::sleep(std::time::Duration::from_millis(500));
+        }
+    });
+}
+
+/// Decrease the counter to stop emiting the data if necesary (counter == 0).
+#[tauri::command]
+pub fn stop_cpu_singlecore_current_usage(
+    counters_state: State<Arc<HashMap<StreamEvent, Mutex<u8>>>>,
+) {
+    let mut counter = counters_state
+        .inner()
+        .get(&StreamEvent::CpuSinglecoreCurrentUsage)
+        .unwrap() // Should never panic if a counter for each variant (key) was inserted when created
+        .lock()
+        .unwrap();
+    let counter = counter.deref_mut();
+    *counter = *counter - 1u8;
+}
+
+
+
+#[derive(Serialize)]
+pub struct SystemStateInfo{
+    frequency: u64,
+    running_processes: usize,
+    avg_load_one: f64,
+    avg_load_five: f64,
+    avg_load_fifteen: f64,
+    uptime: u64,
+    boot_time: u64,
+    distribution_id: String,
+    os_version: Option<String>
+}
+
+/// Try to start emitting system information updates
+/// If the event is already being emmited it does nothing but to
+/// increment the counter.
+/// When the counter is set to 0 the thread will stop executing
+#[tauri::command]
+pub fn emit_system_information(
+    window: Window,
+    counters_state: State<Arc<HashMap<StreamEvent, Mutex<u8>>>>,
+) {
+    let stream_event_kind = StreamEvent::SystemInformation;
+    let listeners_count = Arc::clone(counters_state.inner());
+    let counter_mutex = get_counter_mutex_from_state(&stream_event_kind, counters_state);
+    match increment_counter_and_check(counter_mutex) {
+        StreamEventAction::StartStream => (),
+        _ => return,
+    }
+    std::thread::spawn(move || {
+        let mut sys = System::new_all();
+        loop {
+          sys.refresh_all();
+        
+          let mut max_freq = 0;
+          for cpu in sys.cpus(){
+              if cpu.frequency() > max_freq {
+                  max_freq = cpu.frequency();
+              }
+          }
+          let sys_state_info = SystemStateInfo{
+              frequency: max_freq,
+              running_processes: sys.processes().len(),
+              avg_load_one: sys.load_average().one,
+              avg_load_five: sys.load_average().five,
+              avg_load_fifteen: sys.load_average().fifteen,
+              uptime: sys.uptime(),
+              boot_time: sys.boot_time(),
+              distribution_id: sys.distribution_id(),
+              os_version: sys.os_version()
+          };
+          let resp_msg = serde_json::to_string(&sys_state_info).unwrap();
+            window
+                .emit(stream_event_kind.as_str(), resp_msg)
+                .unwrap();
+
+            // get the current counter mutex
+            let counter_mutex = {
+                listeners_count.get(&stream_event_kind).unwrap() // Should never panic if a counter for each variant (key) was inserted when created
+            };
+            //if there's no component listenig anymore we end this thread by breaking the loop
+            match check_counter(counter_mutex) {
+                StreamEventAction::StopStream => break,
+                _ => (),
+            }
+            //TODO: calc time elapsed
+            std::thread::sleep(std::time::Duration::from_millis(500));
+        }
+    });
+}
+
+/// Decrease the counter to stop emiting the data if necesary (counter == 0).
+#[tauri::command]
+pub fn stop_system_information(
+    counters_state: State<Arc<HashMap<StreamEvent, Mutex<u8>>>>,
+) {
+    let mut counter = counters_state
+        .inner()
+        .get(&StreamEvent::SystemInformation)
+        .unwrap() // Should never panic if a counter for each variant (key) was inserted when created
+        .lock()
+        .unwrap();
+    let counter = counter.deref_mut();
+    *counter = *counter - 1u8;
+}

--- a/src-tauri/src/events/memory.rs
+++ b/src-tauri/src/events/memory.rs
@@ -4,28 +4,23 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use serde::Serialize;
-use sysinfo::{CpuExt, System, SystemExt};
+use sysinfo::{System, SystemExt};
 use tauri::{State, Window};
 
-use crate::systracker::cpu::{CoreBuffer, CpuTracker};
+use crate::systracker::memory::{MemBuffer, MemTracker};
 
 use super::{
-    check_counter, get_counter_mutex_from_state, increment_counter_and_check, StreamEvent,
-    StreamEventAction,
+    get_counter_mutex_from_state, increment_counter_and_check, StreamEvent, StreamEventAction, check_counter,
 };
 
-/// Try to start emitting cpu historical data updates.
-/// If the event is already being emmited it does nothing but to
-/// increment its listeners counter.
-/// When the counter is set to 0 the thread will stop executing
+
 #[tauri::command]
-pub fn emit_cpu_mulitcore_historical_usage(
+pub fn emit_memory_historical_usage(
     window: Window,
-    state: State<Arc<Mutex<CpuTracker>>>,
+    state: State<Arc<Mutex<MemTracker>>>,
     counters_state: State<Arc<HashMap<StreamEvent, Mutex<u8>>>>,
 ) {
-    let stream_event_kind = StreamEvent::CpuMulticoreHistoricalUsage;
+    let stream_event_kind = StreamEvent::MemoryHistoricalUsage;
     let tracker = Arc::clone(state.inner());
     let listeners_count = Arc::clone(counters_state.inner());
     let counter_mutex = get_counter_mutex_from_state(&stream_event_kind, counters_state);
@@ -35,9 +30,8 @@ pub fn emit_cpu_mulitcore_historical_usage(
     }
     std::thread::spawn(move || {
         loop {
-            //window.emit("cpu_multicore_updated", Payload { message: "Tauri is awesome!".into() }).unwrap();
             let tracker = tracker.deref();
-            let data: Option<Vec<CoreBuffer>> = {
+            let data: Option<MemBuffer> = {
                 let mut tracker = match tracker.lock() {
                     Ok(t) => t,
                     Err(_) => continue,
@@ -46,9 +40,9 @@ pub fn emit_cpu_mulitcore_historical_usage(
                 tracker.fetch_usage()
             };
             window
+                // The tracker only returns None after been stoped, wich should never happend
                 .emit(stream_event_kind.as_str(), data.unwrap())
                 .unwrap();
-
             // get the current counter mutex
             let counter_mutex = {
                 listeners_count.get(&stream_event_kind).unwrap() // Should never panic if a counter for each variant (key) was inserted when created
@@ -58,8 +52,6 @@ pub fn emit_cpu_mulitcore_historical_usage(
                 StreamEventAction::StopStream => break,
                 _ => (),
             }
-
-            //TODO: calc time elapsed
             std::thread::sleep(std::time::Duration::from_millis(500));
         }
     });
@@ -67,71 +59,12 @@ pub fn emit_cpu_mulitcore_historical_usage(
 
 /// Try to stop emitting CPU historical data updates by decreasing the counter
 #[tauri::command]
-pub fn stop_cpu_mulitcore_historical_usage(
+pub fn stop_memory_historical_usage(
     counters_state: State<Arc<HashMap<StreamEvent, Mutex<u8>>>>,
 ) {
     let mut counter = counters_state
         .inner()
-        .get(&StreamEvent::CpuMulticoreHistoricalUsage)
-        .unwrap() // Should never panic if a counter for each variant (key) was inserted when created
-        .lock()
-        .unwrap();
-    let counter = counter.deref_mut();
-    *counter = *counter - 1u8;
-}
-
-/// Try to start emitting cpu current usage updates
-/// If the event is already being emmited it does nothing but to
-/// increment the counter.
-/// When the counter is set to 0 the thread will stop executing
-#[tauri::command]
-pub fn emit_cpu_singlecore_current_usage(
-    window: Window,
-    counters_state: State<Arc<HashMap<StreamEvent, Mutex<u8>>>>,
-) {
-    let stream_event_kind = StreamEvent::CpuSinglecoreCurrentUsage;
-    let listeners_count = Arc::clone(counters_state.inner());
-    let counter_mutex = get_counter_mutex_from_state(&stream_event_kind, counters_state);
-    match increment_counter_and_check(counter_mutex) {
-        StreamEventAction::StartStream => (),
-        _ => return,
-    }
-    std::thread::spawn(move || {
-        let mut sys = System::new_all();
-        loop {
-            sys.refresh_cpu();
-            let mut data = 0f32;
-            for cpu in sys.cpus() {
-                data += cpu.cpu_usage();
-            }
-            data = data / sys.cpus().len() as f32;
-            window
-                .emit(stream_event_kind.as_str(), data)
-                .unwrap();
-
-            // get the current counter mutex
-            let counter_mutex = {
-                listeners_count.get(&stream_event_kind).unwrap() // Should never panic if a counter for each variant (key) was inserted when created
-            };
-            //if there's no component listenig anymore we end this thread by breaking the loop
-            match check_counter(counter_mutex) {
-                StreamEventAction::StopStream => break,
-                _ => (),
-            }
-            //TODO: calc time elapsed
-            std::thread::sleep(std::time::Duration::from_millis(500));
-        }
-    });
-}
-
-/// Decrease the counter to stop emiting the data if necesary (counter == 0).
-#[tauri::command]
-pub fn stop_cpu_singlecore_current_usage(
-    counters_state: State<Arc<HashMap<StreamEvent, Mutex<u8>>>>,
-) {
-    let mut counter = counters_state
-        .inner()
-        .get(&StreamEvent::CpuSinglecoreCurrentUsage)
+        .get(&StreamEvent::MemoryHistoricalUsage)
         .unwrap() // Should never panic if a counter for each variant (key) was inserted when created
         .lock()
         .unwrap();
@@ -141,29 +74,12 @@ pub fn stop_cpu_singlecore_current_usage(
 
 
 
-#[derive(Serialize)]
-pub struct SystemStateInfo{
-    frequency: u64,
-    running_processes: usize,
-    avg_load_one: f64,
-    avg_load_five: f64,
-    avg_load_fifteen: f64,
-    uptime: u64,
-    boot_time: u64,
-    distribution_id: String,
-    os_version: Option<String>
-}
-
-/// Try to start emitting system information updates
-/// If the event is already being emmited it does nothing but to
-/// increment the counter.
-/// When the counter is set to 0 the thread will stop executing
 #[tauri::command]
-pub fn emit_system_information(
+pub fn emit_current_memory_usage(
     window: Window,
     counters_state: State<Arc<HashMap<StreamEvent, Mutex<u8>>>>,
 ) {
-    let stream_event_kind = StreamEvent::SystemInformation;
+    let stream_event_kind = StreamEvent::CurrentMemoryUsage;
     let listeners_count = Arc::clone(counters_state.inner());
     let counter_mutex = get_counter_mutex_from_state(&stream_event_kind, counters_state);
     match increment_counter_and_check(counter_mutex) {
@@ -173,30 +89,12 @@ pub fn emit_system_information(
     std::thread::spawn(move || {
         let mut sys = System::new_all();
         loop {
-          sys.refresh_all();
-        
-          let mut max_freq = 0;
-          for cpu in sys.cpus(){
-              if cpu.frequency() > max_freq {
-                  max_freq = cpu.frequency();
-              }
-          }
-          let sys_state_info = SystemStateInfo{
-              frequency: max_freq,
-              running_processes: sys.processes().len(),
-              avg_load_one: sys.load_average().one,
-              avg_load_five: sys.load_average().five,
-              avg_load_fifteen: sys.load_average().fifteen,
-              uptime: sys.uptime(),
-              boot_time: sys.boot_time(),
-              distribution_id: sys.distribution_id(),
-              os_version: sys.os_version()
-          };
-          let resp_msg = serde_json::to_string(&sys_state_info).unwrap();
+            sys.refresh_memory();
+            
             window
-                .emit(stream_event_kind.as_str(), resp_msg)
+                // The tracker only returns None after been stoped, wich should never happend
+                .emit(stream_event_kind.as_str(), sys.used_memory())
                 .unwrap();
-
             // get the current counter mutex
             let counter_mutex = {
                 listeners_count.get(&stream_event_kind).unwrap() // Should never panic if a counter for each variant (key) was inserted when created
@@ -206,20 +104,71 @@ pub fn emit_system_information(
                 StreamEventAction::StopStream => break,
                 _ => (),
             }
-            //TODO: calc time elapsed
             std::thread::sleep(std::time::Duration::from_millis(500));
         }
     });
 }
 
-/// Decrease the counter to stop emiting the data if necesary (counter == 0).
+/// Try to stop emitting CPU historical data updates by decreasing the counter
 #[tauri::command]
-pub fn stop_system_information(
+pub fn stop_curent_memory_usage(
     counters_state: State<Arc<HashMap<StreamEvent, Mutex<u8>>>>,
 ) {
     let mut counter = counters_state
         .inner()
-        .get(&StreamEvent::SystemInformation)
+        .get(&StreamEvent::CurrentMemoryUsage)
+        .unwrap() // Should never panic if a counter for each variant (key) was inserted when created
+        .lock()
+        .unwrap();
+    let counter = counter.deref_mut();
+    *counter = *counter - 1u8;
+}
+
+
+
+#[tauri::command]
+pub fn emit_current_swap_usage(
+    window: Window,
+    counters_state: State<Arc<HashMap<StreamEvent, Mutex<u8>>>>,
+) {
+    let stream_event_kind = StreamEvent::CurrentSwapUsage;
+    let listeners_count = Arc::clone(counters_state.inner());
+    let counter_mutex = get_counter_mutex_from_state(&stream_event_kind, counters_state);
+    match increment_counter_and_check(counter_mutex) {
+        StreamEventAction::StartStream => (),
+        _ => return,
+    }
+    std::thread::spawn(move || {
+        let mut sys = System::new_all();
+        loop {
+            sys.refresh_memory();
+            
+            window
+                // The tracker only returns None after been stoped, wich should never happend
+                .emit(stream_event_kind.as_str(), sys.used_swap())
+                .unwrap();
+            // get the current counter mutex
+            let counter_mutex = {
+                listeners_count.get(&stream_event_kind).unwrap() // Should never panic if a counter for each variant (key) was inserted when created
+            };
+            //if there's no component listenig anymore we end this thread by breaking the loop
+            match check_counter(counter_mutex) {
+                StreamEventAction::StopStream => break,
+                _ => (),
+            }
+            std::thread::sleep(std::time::Duration::from_millis(500));
+        }
+    });
+}
+
+/// Try to stop emitting CPU historical data updates by decreasing the counter
+#[tauri::command]
+pub fn stop_curent_swap_usage(
+    counters_state: State<Arc<HashMap<StreamEvent, Mutex<u8>>>>,
+) {
+    let mut counter = counters_state
+        .inner()
+        .get(&StreamEvent::CurrentSwapUsage)
         .unwrap() // Should never panic if a counter for each variant (key) was inserted when created
         .lock()
         .unwrap();

--- a/src-tauri/src/events/mod.rs
+++ b/src-tauri/src/events/mod.rs
@@ -3,12 +3,16 @@ use std::{collections::HashMap, sync::{Mutex, Arc}, ops::{Deref, DerefMut}};
 use tauri::State;
 
 pub mod cpu;
+pub mod memory;
 
 #[derive(PartialEq, Eq, Hash)]
 pub enum StreamEvent{
     CpuMulticoreHistoricalUsage,
     CpuSinglecoreCurrentUsage,
-    SystemInformation
+    SystemInformation,
+    MemoryHistoricalUsage,
+    CurrentMemoryUsage,
+    CurrentSwapUsage
 }
 
 macro_rules! generate_counters {
@@ -26,14 +30,20 @@ impl StreamEvent{
         match self{
             Self::CpuMulticoreHistoricalUsage => "cpu_multicore_historical_usage",
             Self::CpuSinglecoreCurrentUsage => "cpu_singlecore_current_usage",
-            Self::SystemInformation => "system_information"
+            Self::SystemInformation => "system_information",
+            Self::MemoryHistoricalUsage => "memory_historical_usage",
+            Self::CurrentMemoryUsage => "current_memory_usage",
+            Self::CurrentSwapUsage => "current_swap_usage"
         }
     }
     pub fn get_counters() -> HashMap<StreamEvent, Mutex<u8>> {
         generate_counters!(
             CpuMulticoreHistoricalUsage,
             CpuSinglecoreCurrentUsage,
-            SystemInformation
+            SystemInformation,
+            MemoryHistoricalUsage,
+            CurrentMemoryUsage,
+            CurrentSwapUsage
         )
         // DO NOT REMOVE THIS COMMENT
         //TODO: If you modify the StreamEvent enum, make sure to update this function.

--- a/src-tauri/src/events/mod.rs
+++ b/src-tauri/src/events/mod.rs
@@ -1,0 +1,97 @@
+use std::{collections::HashMap, sync::{Mutex, Arc}, ops::{Deref, DerefMut}};
+
+use tauri::State;
+
+pub mod cpu;
+
+#[derive(PartialEq, Eq, Hash)]
+pub enum StreamEvent{
+    CpuMulticoreHistoricalUsage,
+    CpuSinglecoreCurrentUsage,
+    SystemInformation
+}
+
+macro_rules! generate_counters {
+    ($($variant:ident),*) => {{
+        let mut counter: HashMap<StreamEvent, Mutex<u8>> = HashMap::new();
+        $(
+            counter.insert(StreamEvent::$variant, Mutex::new(0));
+        )*
+        counter
+    }};
+}
+
+impl StreamEvent{
+    pub fn as_str(& self) -> &'static str{
+        match self{
+            Self::CpuMulticoreHistoricalUsage => "cpu_multicore_historical_usage",
+            Self::CpuSinglecoreCurrentUsage => "cpu_singlecore_current_usage",
+            Self::SystemInformation => "system_information"
+        }
+    }
+    pub fn get_counters() -> HashMap<StreamEvent, Mutex<u8>> {
+        generate_counters!(
+            CpuMulticoreHistoricalUsage,
+            CpuSinglecoreCurrentUsage,
+            SystemInformation
+        )
+        // DO NOT REMOVE THIS COMMENT
+        //TODO: If you modify the StreamEvent enum, make sure to update this function.
+        // Add/remove variants as needed.
+    }
+}
+
+/// Extract the mutex that contains the counter from the state hashmap.
+fn get_counter_mutex_from_state<'a>(stream_event_kind: &'a StreamEvent,  counters_state: State<'a, Arc<HashMap<StreamEvent, Mutex<u8>>>>) -> &'a Mutex<u8>{
+    //extract the hashmap
+    let counters = {
+      let c = (counters_state).inner();
+      c.deref()
+    };
+    //get the counter mutex from the hashmap
+    let listeners_count = {
+        counters
+            .get(stream_event_kind)
+            //Do not remove the this unwrap, it enforces us to insert a counter in the state hashmap
+            //for each variant of StreamEvent
+            .unwrap()
+    };
+    listeners_count
+}
+
+pub enum StreamEventAction{
+    StartStream,
+    StopStream,
+    None
+}
+/// Increments the counter inside the mutex and returns true if the counter > 1 after the increment.
+/// True means that there's already a thread streaming the information the counter refers to
+fn increment_counter_and_check(counter_mutex: &Mutex<u8>) -> StreamEventAction{
+    let count = {
+        //TODO: handle unwrap
+        let mut counter = counter_mutex.lock().unwrap();
+        let counter = counter.deref_mut();
+        *counter = *counter + 1u8;
+        *counter
+    };
+    if count > 1 {
+        return StreamEventAction::None;
+    }
+    StreamEventAction::StartStream
+}
+
+fn check_counter(counter_mutex: &Mutex<u8>) -> StreamEventAction{
+    let listeners_count = {
+        let mut counter = counter_mutex
+            .lock()
+            .unwrap();
+        let counter = counter.deref_mut();
+        *counter
+    };
+    //if there's no component listenig anymore we end this thread by breaking the loop
+    if listeners_count == 0 {
+        return StreamEventAction::StopStream;
+    }
+    StreamEventAction::None
+}
+

--- a/src-tauri/src/events/mod.rs
+++ b/src-tauri/src/events/mod.rs
@@ -4,6 +4,7 @@ use tauri::State;
 
 pub mod cpu;
 pub mod memory;
+pub mod process;
 
 #[derive(PartialEq, Eq, Hash)]
 pub enum StreamEvent{
@@ -12,7 +13,8 @@ pub enum StreamEvent{
     SystemInformation,
     MemoryHistoricalUsage,
     CurrentMemoryUsage,
-    CurrentSwapUsage
+    CurrentSwapUsage,
+    CurrentRunningProcesses
 }
 
 macro_rules! generate_counters {
@@ -33,7 +35,8 @@ impl StreamEvent{
             Self::SystemInformation => "system_information",
             Self::MemoryHistoricalUsage => "memory_historical_usage",
             Self::CurrentMemoryUsage => "current_memory_usage",
-            Self::CurrentSwapUsage => "current_swap_usage"
+            Self::CurrentSwapUsage => "current_swap_usage",
+            Self::CurrentRunningProcesses => "current_running_processes"
         }
     }
     pub fn get_counters() -> HashMap<StreamEvent, Mutex<u8>> {
@@ -43,7 +46,8 @@ impl StreamEvent{
             SystemInformation,
             MemoryHistoricalUsage,
             CurrentMemoryUsage,
-            CurrentSwapUsage
+            CurrentSwapUsage,
+            CurrentRunningProcesses
         )
         // DO NOT REMOVE THIS COMMENT
         //TODO: If you modify the StreamEvent enum, make sure to update this function.

--- a/src-tauri/src/events/mod.rs
+++ b/src-tauri/src/events/mod.rs
@@ -14,7 +14,9 @@ pub enum StreamEvent{
     MemoryHistoricalUsage,
     CurrentMemoryUsage,
     CurrentSwapUsage,
-    CurrentRunningProcesses
+    CurrentRunningProcesses,
+    ProcessHistoricalResourceUsage,
+    ProcessInformation
 }
 
 macro_rules! generate_counters {
@@ -36,7 +38,9 @@ impl StreamEvent{
             Self::MemoryHistoricalUsage => "memory_historical_usage",
             Self::CurrentMemoryUsage => "current_memory_usage",
             Self::CurrentSwapUsage => "current_swap_usage",
-            Self::CurrentRunningProcesses => "current_running_processes"
+            Self::CurrentRunningProcesses => "current_running_processes",
+            Self::ProcessHistoricalResourceUsage => "process_historical_resource_usage",
+            Self::ProcessInformation => "process_information"
         }
     }
     pub fn get_counters() -> HashMap<StreamEvent, Mutex<u8>> {
@@ -47,7 +51,9 @@ impl StreamEvent{
             MemoryHistoricalUsage,
             CurrentMemoryUsage,
             CurrentSwapUsage,
-            CurrentRunningProcesses
+            CurrentRunningProcesses,
+            ProcessHistoricalResourceUsage,
+            ProcessInformation
         )
         // DO NOT REMOVE THIS COMMENT
         //TODO: If you modify the StreamEvent enum, make sure to update this function.

--- a/src-tauri/src/events/process.rs
+++ b/src-tauri/src/events/process.rs
@@ -1,0 +1,157 @@
+use std::{
+    collections::HashMap,
+    ops::DerefMut,
+    sync::{Arc, Mutex},
+};
+
+use serde::{Deserialize, Serialize};
+use sysinfo::{Pid, Process, ProcessExt, System, SystemExt};
+use tauri::{State, Window};
+
+use super::{
+    check_counter, get_counter_mutex_from_state, increment_counter_and_check, StreamEvent,
+    StreamEventAction,
+};
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ProcessInformation {
+    pub pid: usize,
+    pub parent_pid: Option<usize>,
+    pub parent_name: Option<String>,
+    pub name: String,
+    pub executable_path: String,
+    pub status: String,
+    pub cpu_usage: f32,
+    pub memory_usage: u64,
+    pub virtual_memory_usage: u64,
+    pub children_processes: Vec<ChildProcessInformation>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ChildProcessInformation {
+    pid: usize,
+    name: String,
+}
+
+#[inline]
+fn return_process_information(
+    processes: &HashMap<Pid, Process>,
+    key: &Pid,
+    cpus_count: usize,
+) -> ProcessInformation {
+    let mut process = ProcessInformation {
+        pid: processes.get(key).unwrap().pid().into(),
+        parent_pid: match processes.get(key).unwrap().parent() {
+            Some(p) => Some(p.into()),
+            None => None,
+        },
+        parent_name: match processes.get(key).unwrap().parent() {
+            Some(parent_pid) => {
+                let parent_process = processes.get(&parent_pid);
+                if parent_process.is_none() {
+                    None
+                } else {
+                    Some(parent_process.unwrap().name().into())
+                }
+            }
+            None => None,
+        },
+        name: processes.get(key).unwrap().name().to_owned(),
+        executable_path: match processes.get(key).unwrap().exe().to_str() {
+            Some(str) => str.to_owned(),
+            None => "".to_owned(),
+        },
+        status: processes.get(key).unwrap().status().to_string(),
+        cpu_usage: processes.get(key).unwrap().cpu_usage() / cpus_count as f32,
+        memory_usage: processes.get(key).unwrap().memory(),
+        virtual_memory_usage: processes.get(key).unwrap().virtual_memory(),
+        children_processes: Vec::new(),
+    };
+    let mut children: Vec<ChildProcessInformation> = Vec::new();
+    for (child_pid, child_process) in processes {
+        if child_process.parent().is_some() {
+            let parent_pid: usize = child_process.parent().unwrap().into();
+            if parent_pid == process.pid {
+                let child_info = ChildProcessInformation {
+                    pid: (*child_pid).into(),
+                    name: child_process.name().into(),
+                };
+                children.push(child_info);
+            }
+        }
+    }
+    process.children_processes = children;
+    process
+}
+
+
+
+#[tauri::command]
+pub fn emit_current_running_processes(
+    window: Window,
+    counters_state: State<Arc<HashMap<StreamEvent, Mutex<u8>>>>,
+) {
+    let stream_event_kind = StreamEvent::CurrentRunningProcesses;
+    let listeners_count = Arc::clone(counters_state.inner());
+    let counter_mutex = get_counter_mutex_from_state(&stream_event_kind, counters_state);
+    match increment_counter_and_check(counter_mutex) {
+        StreamEventAction::StartStream => (),
+        _ => return,
+    }
+    std::thread::spawn(move || {
+        let mut sys = System::new_all();
+        sys.refresh_cpu();
+        let cpus_count = sys.cpus().len();
+        sys.refresh_processes();
+        loop {
+            sys.refresh_processes();
+            let processes = sys.processes();
+
+            let mut processes_list: Vec<ProcessInformation> = Vec::new();
+            for key in processes.keys() {
+                let process = return_process_information(processes, key, cpus_count);
+                processes_list.push(process);
+            }
+            processes_list.sort_unstable_by_key(|process| process.pid);
+            /* if order_by == "pid" {
+                processes_list.sort_unstable_by_key(|process| process.pid);
+            } else if order_by == "parent_pid" {
+                processes_list.sort_unstable_by_key(|process| process.parent_pid);
+            } else if order_by == "cpu_usage" {
+                processes_list
+                    .sort_unstable_by_key(|process| (process.cpu_usage * 1000000 as f32) as i32);
+            } else if order_by == "memory_usage" {
+                processes_list.sort_unstable_by_key(|process| process.memory_usage);
+            } else if order_by == "process_name" {
+                processes_list.sort_unstable_by_key(|process| process.name.clone().to_lowercase());
+            } else {
+                processes_list.sort_unstable_by_key(|process| process.pid);
+            } */
+
+            window.emit(stream_event_kind.as_str(), processes_list).unwrap();
+            
+            let counter_mutex = {
+                listeners_count.get(&stream_event_kind).unwrap() // Should never panic if a counter for each variant (key) was inserted when created
+            };
+            //if there's no component listenig anymore we end this thread by breaking the loop
+            match check_counter(counter_mutex) {
+                StreamEventAction::StopStream => break,
+                _ => (),
+            }
+            std::thread::sleep(std::time::Duration::from_millis(500));
+        }
+    });
+}
+
+/// Try to stop emitting CPU historical data updates by decreasing the counter
+#[tauri::command]
+pub fn stop_current_running_processes(counters_state: State<Arc<HashMap<StreamEvent, Mutex<u8>>>>) {
+    let mut counter = counters_state
+        .inner()
+        .get(&StreamEvent::CurrentRunningProcesses)
+        .unwrap() // Should never panic if a counter for each variant (key) was inserted when created
+        .lock()
+        .unwrap();
+    let counter = counter.deref_mut();
+    *counter = *counter - 1u8;
+}

--- a/src-tauri/src/events/process.rs
+++ b/src-tauri/src/events/process.rs
@@ -1,12 +1,14 @@
 use std::{
     collections::HashMap,
-    ops::DerefMut,
-    sync::{Arc, Mutex},
+    ops::{Deref, DerefMut},
+    sync::{Arc, Mutex, RwLock},
 };
 
 use serde::{Deserialize, Serialize};
 use sysinfo::{Pid, Process, ProcessExt, System, SystemExt};
 use tauri::{State, Window};
+
+use crate::monitors::process::ProcessHistory;
 
 use super::{
     check_counter, get_counter_mutex_from_state, increment_counter_and_check, StreamEvent,
@@ -84,8 +86,6 @@ fn return_process_information(
     process
 }
 
-
-
 #[tauri::command]
 pub fn emit_current_running_processes(
     window: Window,
@@ -128,8 +128,10 @@ pub fn emit_current_running_processes(
                 processes_list.sort_unstable_by_key(|process| process.pid);
             } */
 
-            window.emit(stream_event_kind.as_str(), processes_list).unwrap();
-            
+            window
+                .emit(stream_event_kind.as_str(), processes_list)
+                .unwrap();
+
             let counter_mutex = {
                 listeners_count.get(&stream_event_kind).unwrap() // Should never panic if a counter for each variant (key) was inserted when created
             };
@@ -149,6 +151,160 @@ pub fn stop_current_running_processes(counters_state: State<Arc<HashMap<StreamEv
     let mut counter = counters_state
         .inner()
         .get(&StreamEvent::CurrentRunningProcesses)
+        .unwrap() // Should never panic if a counter for each variant (key) was inserted when created
+        .lock()
+        .unwrap();
+    let counter = counter.deref_mut();
+    *counter = *counter - 1u8;
+}
+
+#[derive(Serialize)]
+pub struct ProcessHistPayload {
+    status: bool,
+    data: Option<ProcessHistory>,
+}
+
+#[tauri::command]
+pub fn emit_process_historical_resource_usage(
+    pid: usize,
+    window: Window,
+    recorded_processes: State<Arc<RwLock<HashMap<usize, ProcessHistory>>>>,
+    counters_state: State<Arc<HashMap<StreamEvent, Mutex<u8>>>>,
+) {
+    let stream_event_kind = StreamEvent::ProcessHistoricalResourceUsage;
+    let recorded_processes = Arc::clone(recorded_processes.inner());
+    let listeners_count = Arc::clone(counters_state.inner());
+    let counter_mutex = get_counter_mutex_from_state(&stream_event_kind, counters_state);
+    match increment_counter_and_check(counter_mutex) {
+        StreamEventAction::StartStream => (),
+        _ => return,
+    }
+    std::thread::spawn(move || {
+        loop {
+            let process_hist_payload: Option<ProcessHistPayload> = {
+                let r = recorded_processes.read().unwrap();
+                let data = r.deref();
+                let try_process_info = data.get(&pid);
+                match try_process_info {
+                    Some(p) => {
+                        let resp = ProcessHistPayload {
+                            status: true,
+                            data: Some(p.clone()),
+                        };
+                        Some(resp)
+                    }
+                    None => None,
+                }
+            };
+            match process_hist_payload {
+                Some(resp) => {
+                    let resp = serde_json::to_string(&resp).unwrap();
+                    window.emit(stream_event_kind.as_str(), resp).unwrap();
+                }
+                None => {
+                    let resp = ProcessHistPayload {
+                        status: false,
+                        data: None,
+                    };
+                    let resp = serde_json::to_string(&resp).unwrap();
+                    window.emit(stream_event_kind.as_str(), resp).unwrap();
+                    break;
+                }
+            }
+            // get the current counter mutex
+            let counter_mutex = {
+                listeners_count.get(&stream_event_kind).unwrap() // Should never panic if a counter for each variant (key) was inserted when created
+            };
+            //if there's no component listenig anymore we end this thread by breaking the loop
+            match check_counter(counter_mutex) {
+                StreamEventAction::StopStream => break,
+                _ => (),
+            }
+            //TODO: calc time elapsed
+            std::thread::sleep(std::time::Duration::from_millis(500));
+        }
+    });
+}
+
+#[derive(Serialize, Clone)]
+pub struct ProcessInfoPayload {
+    status: bool,
+    data: Option<ProcessInformation>,
+}
+
+/// Try to stop emitting CPU historical data updates by decreasing the counter
+#[tauri::command]
+pub fn stop_process_historical_resource_usage(
+    counters_state: State<Arc<HashMap<StreamEvent, Mutex<u8>>>>,
+) {
+    let mut counter = counters_state
+        .inner()
+        .get(&StreamEvent::ProcessHistoricalResourceUsage)
+        .unwrap() // Should never panic if a counter for each variant (key) was inserted when created
+        .lock()
+        .unwrap();
+    let counter = counter.deref_mut();
+    *counter = *counter - 1u8;
+}
+
+#[tauri::command]
+pub fn emit_process_information(
+    pid: usize,
+    window: Window,
+    counters_state: State<Arc<HashMap<StreamEvent, Mutex<u8>>>>,
+) {
+    let stream_event_kind = StreamEvent::ProcessInformation;
+    let listeners_count = Arc::clone(counters_state.inner());
+
+    let counter_mutex = get_counter_mutex_from_state(&stream_event_kind, counters_state);
+    match increment_counter_and_check(counter_mutex) {
+        StreamEventAction::StartStream => (),
+        _ => return,
+    }
+    std::thread::spawn(move || {
+        let mut sys = System::new_all();
+        sys.refresh_cpu();
+        let cpus_count = sys.cpus().len();
+        loop {
+            let exists = sys.refresh_process(Pid::from(pid));
+            println!("emitting");
+            if exists {
+                let process_info =
+                    return_process_information(sys.processes(), &Pid::from(pid), cpus_count);
+                let data = ProcessInfoPayload {
+                    status: true,
+                    data: Some(process_info),
+                };
+                window.emit(stream_event_kind.as_str(), data).unwrap();
+            } else {
+                let data = ProcessInfoPayload {
+                    status: false,
+                    data: None,
+                };
+                window.emit(stream_event_kind.as_str(), data).unwrap();
+                break;
+            }
+            // get the current counter mutex
+            let counter_mutex = {
+                listeners_count.get(&stream_event_kind).unwrap() // Should never panic if a counter for each variant (key) was inserted when created
+            };
+            //if there's no component listenig anymore we end this thread by breaking the loop
+            match check_counter(counter_mutex) {
+                StreamEventAction::StopStream => break,
+                _ => (),
+            }
+
+            std::thread::sleep(std::time::Duration::from_millis(500));
+        }
+    });
+}
+
+/// Try to stop emitting CPU historical data updates by decreasing the counter
+#[tauri::command]
+pub fn stop_process_information(counters_state: State<Arc<HashMap<StreamEvent, Mutex<u8>>>>) {
+    let mut counter = counters_state
+        .inner()
+        .get(&StreamEvent::ProcessInformation)
         .unwrap() // Should never panic if a counter for each variant (key) was inserted when created
         .lock()
         .unwrap();

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,11 +1,21 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
-use std::{sync::{Arc,Mutex}, ops::{Deref, DerefMut}};
+use std::{
+    collections::HashMap,
+    ops::{Deref, DerefMut},
+    sync::{Arc, Mutex},
+};
 
-use systracker::{SystemTracker, cpu::{CpuTracker, CoreBuffer}, memory::{MemTracker, MemBuffer}};
+use events::StreamEvent;
+use systracker::{
+    cpu::{CoreBuffer, CpuTracker},
+    memory::{MemBuffer, MemTracker},
+    SystemTracker,
+};
 use tauri::{State, Window};
 use uuid::Uuid;
+pub mod events;
 pub mod handlers;
 pub mod monitors;
 pub mod streamers;
@@ -14,112 +24,82 @@ pub mod systracker;
 // the payload type must implement `Serialize` and `Clone`.
 #[derive(Clone, serde::Serialize)]
 struct Payload {
-  //message: String
-  message: Vec<CoreBuffer>,
+    //message: String
+    message: Vec<CoreBuffer>,
 }
-
-/// Try to start emitting cpu historical data updates
-/// If the event is already being emmited it does nothing but to
-/// increment the counter.
-/// When the counter is set to 0 the thread will stop executing
-#[tauri::command]
-fn try_emit_cpu_updates(window: Window, state: State<Arc<Mutex<CpuTracker>>> , listeners_count: State<Arc<Mutex<u8>>>) {
-  let tracker = Arc::clone(state.inner());
-  let listeners_count = Arc::clone(listeners_count.inner());
-  let count = {
-    let mut counter = listeners_count.lock().unwrap();
-    let counter = counter.deref_mut();
-    *counter = *counter + 1u8;
-    *counter
-  };
-  if count > 1{
-    return;
-  }
-  std::thread::spawn(move || {
-    loop {
-      //window.emit("cpu_multicore_updated", Payload { message: "Tauri is awesome!".into() }).unwrap();
-      let tracker = tracker.deref();
-      let data: Option<Vec<CoreBuffer>> = {
-        let mut tracker = match tracker.lock(){
-          Ok(t) => t,
-          Err(_) => continue
-        };
-        let tracker = tracker.deref_mut();
-        tracker.fetch_usage()
-      };
-      
-      // get the corrent listeners counter
-      let listeners_count = {
-        let mut counter = listeners_count.lock().unwrap();
-        let counter = counter.deref_mut();
-        *counter
-      };
-      //if there's no component listenig anymore we end this thread by breaking the loop
-      if listeners_count == 0{
-        break;
-      }
-      window.emit("cpu_update", data.unwrap()).unwrap();
-
-      std::thread::sleep(std::time::Duration::from_millis(500));
-    }
-  });
-}
-
-/// Try to stop emitting CPU historical data updates by decreasing the counter
-#[tauri::command]
-fn try_stop_emitting_cpu_updates(listeners_count: State<Arc<Mutex<u8>>>){
-  let mut counter = listeners_count.inner().lock().unwrap();
-  let counter = counter.deref_mut();
-  *counter = *counter - 1u8;
-}
-
 
 // the payload type must implement `Serialize` and `Clone`.
 #[derive(Clone, serde::Serialize)]
 struct MemHistPayload {
-  //message: String
-  message: MemBuffer
+    //message: String
+    message: MemBuffer,
 }
 
 #[tauri::command]
-fn emit_memory_updates(window: Window, state: State<Arc<Mutex<MemTracker>>>, listeners_count: State<Arc<Mutex<u8>>>) {
-  let tracker = Arc::clone(state.inner());
-  let listeners_count = Arc::clone(listeners_count.inner());
-  let count = {
-    let mut counter = listeners_count.lock().unwrap();
-    let counter = counter.deref_mut();
-    *counter = *counter + 1u8;
-    *counter
-  };
-  if count > 1{
-    return;
-  }
-  std::thread::spawn(move || {
-    loop {
-      //window.emit("cpu_multicore_updated", Payload { message: "Tauri is awesome!".into() }).unwrap();
-      let tracker = tracker.deref();
-      let data: Option<MemBuffer> = {
-        let mut tracker = match tracker.lock(){
-          Ok(t) => t,
-          Err(_) => continue
-        };
-        let tracker = tracker.deref_mut();
-        tracker.fetch_usage()
-      };
-      // get the corrent listeners counter
-      let listeners_count = {
+fn emit_memory_updates(
+    window: Window,
+    state: State<Arc<Mutex<MemTracker>>>,
+    counters_state: State<Arc<HashMap<StreamEvent, Mutex<u8>>>>,
+) {
+    let tracker = Arc::clone(state.inner());
+    let counters = {
+        let mut c = (counters_state).inner();
+        let c = c.deref();
+        c
+    };
+    //get the counter mutex from the hashmap
+    let listeners_count = {
+        counters
+            .get(&StreamEvent::CpuMulticoreHistoricalUsage)
+            .unwrap()
+    };
+    let count = {
         let mut counter = listeners_count.lock().unwrap();
         let counter = counter.deref_mut();
+        *counter = *counter + 1u8;
         *counter
-      };
-      //if there's no component listenig anymore we end this thread by breaking the loop
-      if listeners_count == 0{
-        break;
-      }
-      window.emit("mem_update", MemHistPayload { message: data.unwrap() }).unwrap();
-      std::thread::sleep(std::time::Duration::from_millis(500));
+    };
+    if count > 1 {
+        return;
     }
-  });
+    let listeners_count = Arc::clone(counters_state.inner());
+    std::thread::spawn(move || {
+        loop {
+            //window.emit("cpu_multicore_updated", Payload { message: "Tauri is awesome!".into() }).unwrap();
+            let tracker = tracker.deref();
+            let data: Option<MemBuffer> = {
+                let mut tracker = match tracker.lock() {
+                    Ok(t) => t,
+                    Err(_) => continue,
+                };
+                let tracker = tracker.deref_mut();
+                tracker.fetch_usage()
+            };
+            // get the corrent listeners counter
+            let listeners_count = {
+                let mut counter = listeners_count
+                    .get(&StreamEvent::CpuMulticoreHistoricalUsage)
+                    .unwrap()
+                    .lock()
+                    .unwrap();
+                let counter = counter.deref_mut();
+                *counter
+            };
+            //if there's no component listenig anymore we end this thread by breaking the loop
+            if listeners_count == 0 {
+                break;
+            }
+            window
+                .emit(
+                    "mem_update",
+                    MemHistPayload {
+                        message: data.unwrap(),
+                    },
+                )
+                .unwrap();
+            std::thread::sleep(std::time::Duration::from_millis(500));
+        }
+    });
 }
 
 fn main() {
@@ -128,18 +108,15 @@ fn main() {
 
     // Create a CPU tracker that records the last 60 seconds of CPU usage
     let cpu_tracker = SystemTracker::new_cpu_tracker();
-    // Atomic counter to keep track of the amount of components that are currently listening to the event
-    let cpu_listeners_counter: Arc<Mutex<u8>> = Arc::new(Mutex::new(0));
-
     let memory_tracker = SystemTracker::new_mem_tracker();
-    let memory_listener_counter: Arc<Mutex<u8>> = Arc::new(Mutex::new(0));
-    
+
+    let state_counters = StreamEvent::get_counters();
+
     tauri::Builder::default()
         .manage(session_id)
+        .manage(Arc::new(state_counters))
         .manage(Arc::new(Mutex::new(cpu_tracker)))
-        .manage(cpu_listeners_counter)
         .manage(Arc::new(Mutex::new(memory_tracker)))
-        //.manage(memory_listener_counter)
         .invoke_handler(tauri::generate_handler![
             handlers::get_app_session_id,
             handlers::cpu::get_cpu_information,
@@ -147,8 +124,12 @@ fn main() {
             handlers::disk::get_system_disks_information,
             handlers::disk::get_filetree_from_path,
             handlers::disk::get_treemap_from_path,
-            try_emit_cpu_updates,
-            try_stop_emitting_cpu_updates,
+            events::cpu::emit_cpu_mulitcore_historical_usage,
+            events::cpu::stop_cpu_mulitcore_historical_usage,
+            events::cpu::emit_cpu_singlecore_current_usage,
+            events::cpu::stop_cpu_singlecore_current_usage,
+            events::cpu::emit_system_information,
+            events::cpu::stop_system_information
             //emit_memory_updates
         ])
         .run(tauri::generate_context!())

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,19 +1,11 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
-use std::{
-    collections::HashMap,
-    ops::{Deref, DerefMut},
-    sync::{Arc, Mutex},
-};
+use std::sync::{Arc, Mutex};
 
 use events::StreamEvent;
-use systracker::{
-    cpu::{CoreBuffer, CpuTracker},
-    memory::{MemBuffer, MemTracker},
-    SystemTracker,
-};
-use tauri::{State, Window};
+use systracker::SystemTracker;
+
 use uuid::Uuid;
 pub mod events;
 pub mod handlers;
@@ -21,93 +13,13 @@ pub mod monitors;
 pub mod streamers;
 pub mod systracker;
 
-// the payload type must implement `Serialize` and `Clone`.
-#[derive(Clone, serde::Serialize)]
-struct Payload {
-    //message: String
-    message: Vec<CoreBuffer>,
-}
-
-// the payload type must implement `Serialize` and `Clone`.
-#[derive(Clone, serde::Serialize)]
-struct MemHistPayload {
-    //message: String
-    message: MemBuffer,
-}
-
-#[tauri::command]
-fn emit_memory_updates(
-    window: Window,
-    state: State<Arc<Mutex<MemTracker>>>,
-    counters_state: State<Arc<HashMap<StreamEvent, Mutex<u8>>>>,
-) {
-    let tracker = Arc::clone(state.inner());
-    let counters = {
-        let mut c = (counters_state).inner();
-        let c = c.deref();
-        c
-    };
-    //get the counter mutex from the hashmap
-    let listeners_count = {
-        counters
-            .get(&StreamEvent::CpuMulticoreHistoricalUsage)
-            .unwrap()
-    };
-    let count = {
-        let mut counter = listeners_count.lock().unwrap();
-        let counter = counter.deref_mut();
-        *counter = *counter + 1u8;
-        *counter
-    };
-    if count > 1 {
-        return;
-    }
-    let listeners_count = Arc::clone(counters_state.inner());
-    std::thread::spawn(move || {
-        loop {
-            //window.emit("cpu_multicore_updated", Payload { message: "Tauri is awesome!".into() }).unwrap();
-            let tracker = tracker.deref();
-            let data: Option<MemBuffer> = {
-                let mut tracker = match tracker.lock() {
-                    Ok(t) => t,
-                    Err(_) => continue,
-                };
-                let tracker = tracker.deref_mut();
-                tracker.fetch_usage()
-            };
-            // get the corrent listeners counter
-            let listeners_count = {
-                let mut counter = listeners_count
-                    .get(&StreamEvent::CpuMulticoreHistoricalUsage)
-                    .unwrap()
-                    .lock()
-                    .unwrap();
-                let counter = counter.deref_mut();
-                *counter
-            };
-            //if there's no component listenig anymore we end this thread by breaking the loop
-            if listeners_count == 0 {
-                break;
-            }
-            window
-                .emit(
-                    "mem_update",
-                    MemHistPayload {
-                        message: data.unwrap(),
-                    },
-                )
-                .unwrap();
-            std::thread::sleep(std::time::Duration::from_millis(500));
-        }
-    });
-}
-
 fn main() {
     let session_id = Arc::new(Uuid::new_v4());
     monitors::initialize_monitors(Arc::clone(&session_id));
 
     // Create a CPU tracker that records the last 60 seconds of CPU usage
     let cpu_tracker = SystemTracker::new_cpu_tracker();
+    // Create a Memory tracker that records the last 60 seconds of Memory usage
     let memory_tracker = SystemTracker::new_mem_tracker();
 
     let state_counters = StreamEvent::get_counters();
@@ -129,8 +41,13 @@ fn main() {
             events::cpu::emit_cpu_singlecore_current_usage,
             events::cpu::stop_cpu_singlecore_current_usage,
             events::cpu::emit_system_information,
-            events::cpu::stop_system_information
-            //emit_memory_updates
+            events::cpu::stop_system_information,
+            events::memory::emit_memory_historical_usage,
+            events::memory::stop_memory_historical_usage,
+            events::memory::emit_current_memory_usage,
+            events::memory::stop_curent_memory_usage,
+            events::memory::emit_current_swap_usage,
+            events::memory::stop_curent_swap_usage
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,25 +1,155 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
-use std::sync::Arc;
+use std::{sync::{Arc,Mutex}, ops::{Deref, DerefMut}};
 
+use systracker::{SystemTracker, cpu::{CpuTracker, CoreBuffer}, memory::{MemTracker, MemBuffer}};
+use tauri::{State, Window};
 use uuid::Uuid;
 pub mod handlers;
-pub mod streamers;
 pub mod monitors;
+pub mod streamers;
+pub mod systracker;
+
+// the payload type must implement `Serialize` and `Clone`.
+#[derive(Clone, serde::Serialize)]
+struct Payload {
+  //message: String
+  message: Vec<CoreBuffer>,
+}
+
+/// Try to start emitting cpu historical data updates
+/// If the event is already being emmited it does nothing but to
+/// increment the counter.
+/// When the counter is set to 0 the thread will stop executing
+#[tauri::command]
+fn try_emit_cpu_updates(window: Window, state: State<Arc<Mutex<CpuTracker>>> , listeners_count: State<Arc<Mutex<u8>>>) {
+  let tracker = Arc::clone(state.inner());
+  let listeners_count = Arc::clone(listeners_count.inner());
+  let count = {
+    let mut counter = listeners_count.lock().unwrap();
+    let counter = counter.deref_mut();
+    *counter = *counter + 1u8;
+    *counter
+  };
+  if count > 1{
+    return;
+  }
+  std::thread::spawn(move || {
+    loop {
+      //window.emit("cpu_multicore_updated", Payload { message: "Tauri is awesome!".into() }).unwrap();
+      let tracker = tracker.deref();
+      let data: Option<Vec<CoreBuffer>> = {
+        let mut tracker = match tracker.lock(){
+          Ok(t) => t,
+          Err(_) => continue
+        };
+        let tracker = tracker.deref_mut();
+        tracker.fetch_usage()
+      };
+      
+      // get the corrent listeners counter
+      let listeners_count = {
+        let mut counter = listeners_count.lock().unwrap();
+        let counter = counter.deref_mut();
+        *counter
+      };
+      //if there's no component listenig anymore we end this thread by breaking the loop
+      if listeners_count == 0{
+        break;
+      }
+      window.emit("cpu_update", data.unwrap()).unwrap();
+
+      std::thread::sleep(std::time::Duration::from_millis(500));
+    }
+  });
+}
+
+/// Try to stop emitting CPU historical data updates by decreasing the counter
+#[tauri::command]
+fn try_stop_emitting_cpu_updates(listeners_count: State<Arc<Mutex<u8>>>){
+  let mut counter = listeners_count.inner().lock().unwrap();
+  let counter = counter.deref_mut();
+  *counter = *counter - 1u8;
+}
+
+
+// the payload type must implement `Serialize` and `Clone`.
+#[derive(Clone, serde::Serialize)]
+struct MemHistPayload {
+  //message: String
+  message: MemBuffer
+}
+
+#[tauri::command]
+fn emit_memory_updates(window: Window, state: State<Arc<Mutex<MemTracker>>>, listeners_count: State<Arc<Mutex<u8>>>) {
+  let tracker = Arc::clone(state.inner());
+  let listeners_count = Arc::clone(listeners_count.inner());
+  let count = {
+    let mut counter = listeners_count.lock().unwrap();
+    let counter = counter.deref_mut();
+    *counter = *counter + 1u8;
+    *counter
+  };
+  if count > 1{
+    return;
+  }
+  std::thread::spawn(move || {
+    loop {
+      //window.emit("cpu_multicore_updated", Payload { message: "Tauri is awesome!".into() }).unwrap();
+      let tracker = tracker.deref();
+      let data: Option<MemBuffer> = {
+        let mut tracker = match tracker.lock(){
+          Ok(t) => t,
+          Err(_) => continue
+        };
+        let tracker = tracker.deref_mut();
+        tracker.fetch_usage()
+      };
+      // get the corrent listeners counter
+      let listeners_count = {
+        let mut counter = listeners_count.lock().unwrap();
+        let counter = counter.deref_mut();
+        *counter
+      };
+      //if there's no component listenig anymore we end this thread by breaking the loop
+      if listeners_count == 0{
+        break;
+      }
+      window.emit("mem_update", MemHistPayload { message: data.unwrap() }).unwrap();
+      std::thread::sleep(std::time::Duration::from_millis(500));
+    }
+  });
+}
 
 fn main() {
     let session_id = Arc::new(Uuid::new_v4());
     monitors::initialize_monitors(Arc::clone(&session_id));
+
+    // Create a CPU tracker that records the last 60 seconds of CPU usage
+    let cpu_tracker = SystemTracker::new_cpu_tracker();
+    // Atomic counter to keep track of the amount of components that are currently listening to the event
+    let cpu_listeners_counter: Arc<Mutex<u8>> = Arc::new(Mutex::new(0));
+
+    let memory_tracker = SystemTracker::new_mem_tracker();
+    let memory_listener_counter: Arc<Mutex<u8>> = Arc::new(Mutex::new(0));
+    
     tauri::Builder::default()
         .manage(session_id)
+        .manage(Arc::new(Mutex::new(cpu_tracker)))
+        .manage(cpu_listeners_counter)
+        .manage(Arc::new(Mutex::new(memory_tracker)))
+        //.manage(memory_listener_counter)
         .invoke_handler(tauri::generate_handler![
-          handlers::get_app_session_id,
-          handlers::cpu::get_cpu_information,
-          handlers::memory::get_memory_information,
-          handlers::disk::get_system_disks_information,
-          handlers::disk::get_filetree_from_path,
-          handlers::disk::get_treemap_from_path
+            handlers::get_app_session_id,
+            handlers::cpu::get_cpu_information,
+            handlers::memory::get_memory_information,
+            handlers::disk::get_system_disks_information,
+            handlers::disk::get_filetree_from_path,
+            handlers::disk::get_treemap_from_path,
+            try_emit_cpu_updates,
+            try_stop_emitting_cpu_updates,
+            //emit_memory_updates
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,9 +1,10 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
-use std::sync::{Arc, Mutex};
+use std::{sync::{Arc, Mutex, RwLock}, collections::HashMap};
 
 use events::StreamEvent;
+use monitors::process::{ProcessHistory, start_processes_monitor};
 use systracker::SystemTracker;
 
 use uuid::Uuid;
@@ -15,18 +16,23 @@ pub mod systracker;
 
 fn main() {
     let session_id = Arc::new(Uuid::new_v4());
-    monitors::initialize_monitors(Arc::clone(&session_id));
 
     // Create a CPU tracker that records the last 60 seconds of CPU usage
     let cpu_tracker = SystemTracker::new_cpu_tracker();
     // Create a Memory tracker that records the last 60 seconds of Memory usage
     let memory_tracker = SystemTracker::new_mem_tracker();
 
+    // Start a thread that records the last 60 seconds of each process resource usage
+    let recorded_processes: HashMap<usize, ProcessHistory> = HashMap::new();
+    let recorded_processes_arc = Arc::new(RwLock::new(recorded_processes));
+    start_processes_monitor(Arc::clone(&recorded_processes_arc));
+
     let state_counters = StreamEvent::get_counters();
 
     tauri::Builder::default()
         .manage(session_id)
         .manage(Arc::new(state_counters))
+        .manage(Arc::clone(&recorded_processes_arc))
         .manage(Arc::new(Mutex::new(cpu_tracker)))
         .manage(Arc::new(Mutex::new(memory_tracker)))
         .invoke_handler(tauri::generate_handler![
@@ -49,7 +55,11 @@ fn main() {
             events::memory::emit_current_swap_usage,
             events::memory::stop_curent_swap_usage,
             events::process::emit_current_running_processes,
-            events::process::stop_current_running_processes
+            events::process::stop_current_running_processes,
+            events::process::emit_process_historical_resource_usage,
+            events::process::stop_process_historical_resource_usage,
+            events::process::emit_process_information,
+            events::process::stop_process_information
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -47,7 +47,9 @@ fn main() {
             events::memory::emit_current_memory_usage,
             events::memory::stop_curent_memory_usage,
             events::memory::emit_current_swap_usage,
-            events::memory::stop_curent_swap_usage
+            events::memory::stop_curent_swap_usage,
+            events::process::emit_current_running_processes,
+            events::process::stop_current_running_processes
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/monitors/mod.rs
+++ b/src-tauri/src/monitors/mod.rs
@@ -1,9 +1,9 @@
-use std::{sync::{Arc, Mutex, RwLock}, net::{TcpListener, TcpStream}, thread, collections::HashMap};
+use std::{sync::{Arc, Mutex}, net::{TcpListener, TcpStream}, thread};
 use tungstenite::{accept, WebSocket};
 use uuid::Uuid;
 use crate::streamers;
 
-use self::{cpu::start_cpu_monitor, memory::start_memory_monitor, process::{ProcessHistory, start_processes_monitor}};
+use self::{cpu::start_cpu_monitor, memory::start_memory_monitor};
 
 pub mod cpu;
 pub mod memory;
@@ -73,19 +73,19 @@ pub fn initialize_monitors(app_session_id: Arc<Uuid>){
     let memory_timelapse_data: Vec<u64> = Vec::new();
     let memory_timelapse_data_arc = Arc::new(Mutex::new(memory_timelapse_data));
 
-    let recorded_processes: HashMap<usize, ProcessHistory> = HashMap::new();
-    let recorded_processes_arc = Arc::new(RwLock::new(recorded_processes));
+    /* let recorded_processes: HashMap<usize, ProcessHistory> = HashMap::new();
+    let recorded_processes_arc = Arc::new(RwLock::new(recorded_processes)); */
 
     start_cpu_monitor(Arc::clone(&cpu_timelapse_data_arc));
     start_memory_monitor(Arc::clone(&memory_timelapse_data_arc));
-    start_processes_monitor(Arc::clone(&recorded_processes_arc));
+    /* start_processes_monitor(Arc::clone(&recorded_processes_arc)); */
 
     let server = TcpListener::bind("127.0.0.1:9001").unwrap();
     thread::spawn(move ||{
         for stream in server.incoming(){
             let cpu_timelapse_data_arc = Arc::clone(&cpu_timelapse_data_arc);
             let memory_timelapse_data_arc = Arc::clone(&memory_timelapse_data_arc);
-            let recorded_processes = Arc::clone(&recorded_processes_arc);
+            //let recorded_processes = Arc::clone(&recorded_processes_arc);
             let app_session_id = Arc::clone(&app_session_id);
             thread::spawn(move||{
                 let mut websocket = accept(stream.unwrap()).unwrap();
@@ -126,7 +126,7 @@ pub fn initialize_monitors(app_session_id: Arc<Uuid>){
                         streamers::cpu::handle_current_system_state_websocket(websocket);
                     },
                     MRT::ProcessResourcesUsage =>{
-                        streamers::process::handle_process_resource_usage_websocket(websocket, recorded_processes);
+                        //streamers::process::handle_process_resource_usage_websocket(websocket, recorded_processes);
                     }
                     MRT::ProcessInformation => {
                         streamers::process::handle_process_information_websocket(websocket);

--- a/src-tauri/src/streamers/cpu.rs
+++ b/src-tauri/src/streamers/cpu.rs
@@ -158,3 +158,7 @@ pub fn handle_current_system_state_websocket(
     println!("websocket closed");
 }
 //END SYSTEM GENERAL INFO
+
+
+/*********************** EVENT IMPLEMENTATION**********************/
+

--- a/src-tauri/src/streamers/process.rs
+++ b/src-tauri/src/streamers/process.rs
@@ -186,7 +186,7 @@ pub fn handle_process_resource_usage_websocket(
             let try_process_info = data.get(&key);
             match try_process_info{
                 Some(p) => {
-                    let p = p.deref().clone();
+                    let p = p.clone();
                     p
                 },
                 None => {

--- a/src-tauri/src/systracker/cpu.rs
+++ b/src-tauri/src/systracker/cpu.rs
@@ -1,0 +1,135 @@
+use std::{sync::{Mutex, Arc, atomic::AtomicBool}, time::{Duration, Instant}, thread, ops::{DerefMut, Deref}};
+
+use serde::Serialize;
+use sysinfo::{System, SystemExt, CpuExt};
+
+use super::TrackerCapacity;
+
+
+
+/// Wraps a vector that contains the historial CPU-core usage recorded by the CpuTracker
+/// over the lapse specified when `new_cpu_tracker()` or `new_cpu_tracker_with_capacity()`
+/// was called.
+#[derive(Debug, Clone, Serialize)]
+pub struct CoreBuffer{
+    buffer: Vec<f32>
+}
+
+impl CoreBuffer{
+    fn new(capacity: usize) -> Self{
+        let mut cb = CoreBuffer { buffer: Vec::with_capacity(capacity) };
+        for _ in 0..capacity{
+            cb.buffer.push(0f32)
+        }
+        cb
+    }
+}
+
+/// A struct that represents a CPU usage tracker.
+/// When created, it spawns a background thread that records the usage of each CPU-Core on the system.
+/// The information is updated twice per second.
+/// 
+/// To get the recorded data up to 'now', call `fetch_usage()`
+/// and to stop recording CPU usage, call `stop()`.
+/// 
+/// Once stoped, the `fetch_usage()` method will always return `None` 
+pub struct CpuTracker{
+    buffer: Arc<Mutex<Vec<CoreBuffer>>>,
+    stop_flag: Arc<AtomicBool>,
+    capacity: TrackerCapacity
+}
+
+impl CpuTracker{
+    pub (crate) fn default() -> CpuTracker{
+        CpuTracker::with_capacity(TrackerCapacity::ONE) 
+    }
+
+    //
+    //Create a tracker that records each cpu on the system for the specified lapse
+    //
+    pub (crate) fn with_capacity(minutes: TrackerCapacity) -> CpuTracker{
+        let capacity: usize = minutes.to_buffer_size();
+        let mut sys = System::new_all();
+        sys.refresh_cpu();
+
+        let mut buff: Vec<CoreBuffer> = Vec::with_capacity(sys.cpus().len());
+        for _ in sys.cpus(){
+            buff.push(CoreBuffer::new(capacity));
+        }
+        let tracker = CpuTracker{
+            buffer: Arc::new(Mutex::new(buff)),
+            stop_flag: Arc::new(AtomicBool::new(false)),
+            capacity: minutes
+        };
+        let tracker_buffer = Arc::clone(&tracker.buffer);
+        let stop_flag = Arc::clone(&tracker.stop_flag);
+        refresh_loop(sys, tracker.capacity, tracker_buffer, stop_flag);
+        tracker
+    }
+    /// Stop the background thread that updates the buffer where
+    /// historical CPU usage information is saved.
+    /// 
+    /// Consider that calling this method will make later calls to `fetch_usage()`
+    /// always return `None`.
+    pub fn stop(&mut self){
+        self.stop_flag.store(true, std::sync::atomic::Ordering::Relaxed);
+    }
+    /// Fetch the the historical CPU usage information recorded from 'capacity' ago
+    /// up until 'now'. Consider that if the `CpuTracker` was crated recently,
+    /// depending of the tracker capacity, the first positions of the buffer will be
+    /// filled with 0s for quite some time.
+    /// 
+    /// Also, consider that calling `stop()` will make later calls to this method
+    /// always return `None`.
+    pub fn fetch_usage(&mut self) -> Option<Vec<CoreBuffer>>{
+        if self.stop_flag.load(std::sync::atomic::Ordering::Relaxed) {
+            return None;
+        }
+        let resp: Vec<CoreBuffer> = {    
+            let try_buffers = self.buffer.lock();
+            let buffers = match try_buffers {
+                Err(_) => return None,
+                Ok(b) => b,
+            };
+            let r = buffers.deref().clone();
+            r
+        };
+        Some(resp)
+    }
+}
+
+fn refresh_loop(mut sys: System, capacity: TrackerCapacity, buffer: Arc<Mutex<Vec<CoreBuffer>>>, stop_flag: Arc<AtomicBool>){
+    thread::spawn(move ||{
+        loop{
+            let now = Instant::now();
+            sys.refresh_cpu();
+            let buffer_size: usize = capacity.to_buffer_size();
+            {
+                let try_buffers = buffer.lock();
+                let mut buffers = match try_buffers {
+                    Err(_) => continue,
+                    Ok(b) => b,
+                };
+                let buffers = buffers.deref_mut();
+                for (i, core_buff) in buffers.iter_mut().enumerate(){
+                    let core_buffer = &mut core_buff.buffer;
+                    core_buffer.rotate_left(1);
+                    let cpu_usage = match sys.cpus().get(i){
+                        Some(c) => c.cpu_usage(),
+                        None => 0f32,
+                    } ;
+                    core_buffer[buffer_size - 1] = cpu_usage;
+                }
+            }
+            let elapsed = now.elapsed().as_millis();
+            if elapsed >= 500 {
+                continue;
+            }
+            if stop_flag.load(std::sync::atomic::Ordering::Relaxed) {
+                break;
+            }
+            thread::sleep(Duration::from_millis(500))
+        }
+    });
+    
+}

--- a/src-tauri/src/systracker/memory.rs
+++ b/src-tauri/src/systracker/memory.rs
@@ -1,0 +1,124 @@
+use std::{sync::{Mutex, Arc, atomic::AtomicBool}, time::{Duration, Instant}, thread, ops::{DerefMut, Deref}};
+
+use serde::Serialize;
+use sysinfo::{System, SystemExt};
+
+use super::TrackerCapacity;
+
+
+/// Wraps a buffer that contains historial memory usage recorded by a MemTracker
+/// over the lapse specified when `new_mem_tracker()` or `new_mem_tracker_with_capacity()`
+/// was called.
+#[derive(Debug, Clone, Serialize)]
+pub struct MemBuffer{
+    buffer: Vec<u64>
+}
+
+impl MemBuffer{
+    fn new(capacity: usize) -> Self{
+        let mut mb = MemBuffer { buffer: Vec::with_capacity(capacity) };
+        for _ in 0..capacity{
+            mb.buffer.push(0)
+        }
+        mb
+    }
+}
+
+/// A struct that represents a memory usage tracker.
+/// When created, it spawns a background thread that records the system's used memory (in bytes).
+/// The information is updated twice per second.
+/// 
+/// To get the recorded data up to 'now', call `fetch_usage()`
+/// and to stop recording CPU usage, call `stop()`.
+/// 
+/// Once stoped, the `fetch_usage()` method will always return `None` 
+pub struct MemTracker{
+    buffer: Arc<Mutex<MemBuffer>>,
+    stop_flag: Arc<AtomicBool>,
+    capacity: TrackerCapacity
+}
+
+impl MemTracker{
+    pub (crate) fn default() -> MemTracker{
+        MemTracker::with_capacity(TrackerCapacity::ONE) 
+    }
+    //
+    //Create a tracker that records memory usage for the specified lapse
+    //
+    pub (crate) fn with_capacity(minutes: TrackerCapacity) -> MemTracker{
+        let capacity: usize = minutes.to_buffer_size();
+        let sys = System::new_all();
+
+        let buff: MemBuffer = MemBuffer::new(capacity);
+
+        let tracker = MemTracker{
+            buffer: Arc::new(Mutex::new(buff)),
+            stop_flag: Arc::new(AtomicBool::new(false)),
+            capacity: minutes
+        };
+        let tracker_buffer = Arc::clone(&tracker.buffer);
+        let stop_flag = Arc::clone(&tracker.stop_flag);
+        refresh_loop(sys, tracker.capacity, tracker_buffer, stop_flag);
+        tracker
+    }
+    /// Stop the background thread that updates the buffer where
+    /// historical memory usage information is saved.
+    /// 
+    /// Consider that calling this method will make later calls to `fetch_usage()`
+    /// always return `None`.
+    pub fn stop(&mut self){
+        self.stop_flag.store(true, std::sync::atomic::Ordering::Relaxed);
+    }
+    /// Fetch the the historical memory usage information recorded from 'capacity' ago
+    /// up until 'now'. Consider that if the `MemTracker` was crated recently,
+    /// depending of the tracker capacity, the first positions of the buffer will be
+    /// filled with 0s for quite some time.
+    /// 
+    /// Also, consider that calling `stop()` will make later calls to this method
+    /// always return `None`.
+    pub fn fetch_usage(&mut self) -> Option<MemBuffer>{
+        if self.stop_flag.load(std::sync::atomic::Ordering::Relaxed) {
+            return None;
+        }
+        let resp: MemBuffer = {    
+            let try_buffers = self.buffer.lock();
+            let buffers = match try_buffers {
+                Err(_) => return None,
+                Ok(b) => b,
+            };
+            let r = buffers.deref().clone();
+            r
+        };
+        Some(resp)
+    }
+}
+
+
+fn refresh_loop(mut sys: System, capacity: TrackerCapacity, buffer: Arc<Mutex<MemBuffer>>, stop_flag: Arc<AtomicBool>){
+    thread::spawn(move ||{
+        loop{
+            let now = Instant::now();
+            sys.refresh_memory();
+            let buffer_size: usize = capacity.to_buffer_size();
+            {
+                let try_buffer = buffer.lock();
+                let mut buffer = match try_buffer {
+                    Err(_) => continue,
+                    Ok(b) => b,
+                };
+                let mem_buffer = &mut buffer.deref_mut().buffer;
+                mem_buffer.rotate_left(1);
+                mem_buffer[buffer_size - 1] = sys.used_memory();
+            }
+            let elapsed = now.elapsed().as_millis();
+            if elapsed >= 500 {
+                continue;
+            }
+            if stop_flag.load(std::sync::atomic::Ordering::Relaxed) {
+                break;
+            }
+            thread::sleep(Duration::from_millis(500))
+        }
+    });
+    
+}

--- a/src-tauri/src/systracker/mod.rs
+++ b/src-tauri/src/systracker/mod.rs
@@ -1,0 +1,70 @@
+use cpu::CpuTracker;
+use memory::MemTracker;
+
+pub mod cpu;
+pub mod memory;
+
+
+/// Represents the amount of time (in minutes) that a tracker will record.
+///
+/// Internally this is used to calculate the size of the buffer
+/// where the resource information is beign saved.   
+#[derive(Clone, Copy)]
+pub enum TrackerCapacity{
+    /// One minute
+    ONE,
+    /// Five minutes
+    FIVE,
+    /// Ten minutes
+    TEN,
+    /// Custom (up to 255 minutes)
+    CUSTOM(u8)
+}
+
+impl TrackerCapacity{
+    fn to_buffer_size(self) -> usize{
+        match self{
+            TrackerCapacity::ONE => 120,
+            TrackerCapacity::FIVE => 120 * 5,
+            TrackerCapacity::TEN => 120 * 10,
+            TrackerCapacity::CUSTOM(m) => 120 * m as usize
+        }
+    }
+}
+
+pub struct SystemTracker;
+
+impl SystemTracker{
+    /// Create a tracker that records each system's CPU-core usage over 1 minute.
+    /// ```
+    /// let mut cpu_tracker = SystemTracker::new_cpu_tracker();
+    /// ```
+    pub fn new_cpu_tracker() -> CpuTracker{
+        CpuTracker::default()
+    }
+
+    /// Create a tracker that records each system's CPU-core usage over a specified lapse.
+    /// ```
+    /// let mut cpu_tracker = SystemTracker::new_cpu_tracker_with_capacity(TrackerCapacity::FIVE);
+    /// let mut cpu_tracker = SystemTracker::new_cpu_tracker_with_capacity(TrackerCapacity::CUSTOM(20));
+    /// ```
+    pub fn new_cpu_tracker_with_capacity(minutes: TrackerCapacity) -> CpuTracker{
+        CpuTracker::with_capacity(minutes)
+    }
+
+    /// Create a tracket that record memory usage over 1 minute.
+    /// ```
+    /// let mut cpu_tracker = SystemTracker::new_mem_tracker();
+    /// ```
+    pub fn new_mem_tracker() -> MemTracker{
+        MemTracker::default()
+    }
+    /// Create a tracket that record memory usage over a custom lapse.
+    /// ```
+    /// let mut mem_tracker = SystemTracker::new_mem_tracker_with_capacity(TrackerCapacity::FIVE);
+    /// let mut mem_tracker = SystemTracker::new_mem_tracker_with_capacity(TrackerCapacity::CUSTOM(20));
+    /// ```
+    pub fn new_mem_tracker_with_capacity(minutes: TrackerCapacity) -> MemTracker{
+        MemTracker::with_capacity(minutes)
+    }
+}

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -3,6 +3,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { AppColorMode, OS_type } from './types/app-types';
 import { appWindow } from '@tauri-apps/api/window';
 import { invoke } from '@tauri-apps/api';
+import { emit, listen } from '@tauri-apps/api/event'
 
 @Component({
   selector: 'app-root',
@@ -48,6 +49,27 @@ export class AppComponent {
       this.color_mode = "OS";
     }
     this.update_color_mode();
+
+    /* invoke<any>("emit_cpu_updates", { }).then((response) => {
+      //this.greetingMessage = text;
+      console.log(response)
+    }); */
+    /* invoke<any>("emit_memory_updates", { }).then((response) => {
+      //this.greetingMessage = text;
+      console.log(response)
+    }); */
+
+    /* const unlisten_cpu = await listen('cpu_update', (event) => {
+      // event.event is the event name (useful if you want to use a single callback fn for multiple event types)
+      // event.payload is the payload object
+      console.log("cpu ====>", event.payload)
+    }) */
+
+    /* const unlisten_mem = await listen('mem_update', (event) => {
+      // event.event is the event name (useful if you want to use a single callback fn for multiple event types)
+      // event.payload is the payload object
+      console.log("memory ===>", event.payload)
+    }) */
     
   }
 

--- a/src/app/page/cpu/cpu.component.html
+++ b/src/app/page/cpu/cpu.component.html
@@ -37,11 +37,9 @@
             </div>
             <span class="cpu-brand-span">{{cpu_info.brand}}</span>
         </div>
-        <app-current-multicore-usage *ngIf="current_chart_type=='current'"
-            [core_count_ready_event]="core_count_ready_subject.asObservable()"
+        <app-current-multicore-usage *ngIf="current_chart_type=='current' && this.cpu_info.logical_core_count != 0"
             [core_count]="this.cpu_info.logical_core_count"></app-current-multicore-usage>
-        <app-timelapse-multicore-usage *ngIf="current_chart_type=='timelapse'"
-            [core_count_ready_event]="core_count_ready_subject.asObservable()"
+        <app-timelapse-multicore-usage *ngIf="current_chart_type=='timelapse' && this.cpu_info.logical_core_count != 0"
             [core_count]="this.cpu_info.logical_core_count"></app-timelapse-multicore-usage>
     </div>
     <app-current-singlecore-usage></app-current-singlecore-usage>

--- a/src/app/page/cpu/current-multicore-usage/current-multicore-usage.component.ts
+++ b/src/app/page/cpu/current-multicore-usage/current-multicore-usage.component.ts
@@ -26,7 +26,6 @@ export class CurrentMulticoreUsageComponent {
     this.chart.chart?.resize();
   }
 
-  socket!: WebSocket;
   public barChartLegend = false;
   public barChartPlugins = [];
   

--- a/src/app/page/cpu/current-multicore-usage/current-multicore-usage.component.ts
+++ b/src/app/page/cpu/current-multicore-usage/current-multicore-usage.component.ts
@@ -72,7 +72,7 @@ export class CurrentMulticoreUsageComponent {
 
   ngOnDestroy(){
     this.unlisten_update_event();
-    invoke<any>("stop_cpu_singlecore_current_usage", { });
+    invoke<any>("emit_cpu_mulitcore_historical_usage", { });
   }
 
   private update_chart(data: CoreBuffer[]){

--- a/src/app/page/cpu/current-singlecore-usage/current-singlecore-usage.component.html
+++ b/src/app/page/cpu/current-singlecore-usage/current-singlecore-usage.component.html
@@ -1,4 +1,4 @@
-<div class="mb-2">
+<div class="mb-2" >
     <span>{{'current_singlecore_usage.AVG_utilization' | translate}}</span>
     <div class="bar card">
         <div class="inner-bar" style.min-width="{{current_utilization}}%"></div>

--- a/src/app/page/cpu/current-singlecore-usage/current-singlecore-usage.component.ts
+++ b/src/app/page/cpu/current-singlecore-usage/current-singlecore-usage.component.ts
@@ -3,7 +3,6 @@ import { Component, NgZone } from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
 import { invoke } from '@tauri-apps/api';
 import { listen } from '@tauri-apps/api/event';
-import { AppComponent } from 'src/app/app.component';
 
 @Component({
   selector: 'app-current-singlecore-usage',
@@ -13,7 +12,7 @@ import { AppComponent } from 'src/app/app.component';
   imports: [TranslateModule, CommonModule]
 })
 export class CurrentSinglecoreUsageComponent {
-  private socket!: WebSocket;
+
   public current_utilization!: number;
 
   private unlisten_update_event: any;
@@ -21,8 +20,8 @@ export class CurrentSinglecoreUsageComponent {
   constructor(private ngZone: NgZone){}
 
   ngOnInit() {
-    this.unlisten_update_event = invoke<any>("emit_cpu_singlecore_current_usage", { }).then(async ()=>{
-        this.unlisten_update_event = listen('cpu_singlecore_current_usage', (event) => {
+    invoke<any>("emit_cpu_singlecore_current_usage", { }).then(async ()=>{
+        this.unlisten_update_event = await listen('cpu_singlecore_current_usage', (event) => {
           this.update_ui(event.payload as number);
         });
     })
@@ -35,7 +34,7 @@ export class CurrentSinglecoreUsageComponent {
   }
 
   ngOnDestroy(){
-    this.unlisten_update_event();
+    this.unlisten_update_event()
     invoke<any>("stop_cpu_singlecore_current_usage", { });
   }
 

--- a/src/app/page/cpu/timelapse-multicore-usage/timelapse-multicore-usage.component.ts
+++ b/src/app/page/cpu/timelapse-multicore-usage/timelapse-multicore-usage.component.ts
@@ -46,8 +46,8 @@ export class TimelapseMulticoreUsageComponent {
       for(let i = 0; i < this.core_count; i++){
         this.cores_data.push([])
       }
-      invoke<any>("try_emit_cpu_updates", { }).then(async ()=>{
-        this.unlisten_update_event = await listen('cpu_update', (event) => {
+      invoke<any>("emit_cpu_mulitcore_historical_usage", { }).then(async ()=>{
+        this.unlisten_update_event = await listen('cpu_multicore_historical_usage', (event) => {
           this.update_chart(event.payload as CoreBuffer[]);
         })
       })
@@ -58,7 +58,7 @@ export class TimelapseMulticoreUsageComponent {
 
   ngOnDestroy() {
     this.unlisten_update_event();
-    invoke<any>("try_stop_emitting_cpu_updates", { });
+    invoke<any>("stop_cpu_mulitcore_historical_usage", { });
   }
 
   private update_chart(data: CoreBuffer[]){

--- a/src/app/page/cpu/timelapse-multicore-usage/timelapse-multicore-usage.component.ts
+++ b/src/app/page/cpu/timelapse-multicore-usage/timelapse-multicore-usage.component.ts
@@ -1,14 +1,14 @@
-import { Component, Input, ViewChild } from '@angular/core';
+import { Component, Input} from '@angular/core';
 import { Observable, Subscription } from 'rxjs';
 import { TimelapseSingleUsageComponent } from './timelapse-single-usage/timelapse-single-usage.component';
 import { CommonModule } from '@angular/common';
 import { CpuDataUpdateNotifierService } from './service/cpu-data-update-notifier.service';
 import { NgChartsModule } from 'ng2-charts';
-import { ChartConfiguration } from 'chart.js';
 import { AppearanceSettingComponent } from './appearance-setting/appearance-setting.component';
-import { CpuPreferences } from 'src/app/types/cpu-types';
+import { CoreBuffer} from 'src/app/types/cpu-types';
 import { CpuPreferencesService } from 'src/app/services/cpu-preferences.service';
-import { AppComponent } from 'src/app/app.component';
+import { invoke } from '@tauri-apps/api';
+import { listen } from '@tauri-apps/api/event';
 
 @Component({
   selector: 'app-timelapse-multicore-usage',
@@ -39,52 +39,36 @@ export class TimelapseMulticoreUsageComponent {
     this.line_color = pref.timelapse.line_color;
   }
 
+  unlisten_update_event: any;//function to 'unsubscribe' from update event
+
   ngOnInit(){
     if(this.core_count){
-      this.onCoreCountReady(this.core_count)
-      return;
+      for(let i = 0; i < this.core_count; i++){
+        this.cores_data.push([])
+      }
+      invoke<any>("try_emit_cpu_updates", { }).then(async ()=>{
+        this.unlisten_update_event = await listen('cpu_update', (event) => {
+          this.update_chart(event.payload as CoreBuffer[]);
+        })
+      })
     }
-    this.eventsSubscription = this.core_count_ready_event.subscribe((core_count) => {
-      this.onCoreCountReady(core_count);
-    });
   }
   ngAfterViewInit(){
   }
 
   ngOnDestroy() {
-    if(this.eventsSubscription){
-      this.eventsSubscription.unsubscribe();
-    }
-    if (this.socket && this.socket.readyState === WebSocket.OPEN) {
-      this.socket.close();
-    }
+    this.unlisten_update_event();
+    invoke<any>("try_stop_emitting_cpu_updates", { });
   }
 
-  private onCoreCountReady(core_count: number){
-    //this.cores_data = [];
-    for(let i = 0; i < core_count; i++){
-      this.cores_data.push([])
-    }
-    this.socket = new WebSocket("ws://127.0.0.1:9001");
-    this.socket.onopen = () => {
-      this.socket.send(AppComponent.app_session_id);
-      this.socket.send("cpu_timelapse_multicore_usage");
-    }
-    this.socket.onmessage = (event) => {
-      let data: number[][] = JSON.parse(event.data) as number[][];
-      //TODO: instead of sending 120 arrays (from rust-tauri) of 'core_count' len each, try and test 
-      //sending 'core_count' arrays of 120 numbers to avoid doing the following data
-      //manipulation in js  
-      let lectures_count = data.length;
-      
-      for(let i = 0; i < core_count; i++){
-        this.cores_data[i].length = 0;
-        for(let j = 0; j < lectures_count; j++){
-          this.cores_data[i].push(data[j][i]);
-        }
+  private update_chart(data: CoreBuffer[]){
+    for(let i = 0; i < this.core_count; i++){
+      this.cores_data[i].length = 0;
+      for(let n of data[i].buffer){
+        this.cores_data[i].push(n)
       }
-      this.core_data_update_notifier.notifyAll();
     }
+    this.core_data_update_notifier.notifyAll();
   }
 
 }

--- a/src/app/page/cpu/timelapse-multicore-usage/timelapse-multicore-usage.component.ts
+++ b/src/app/page/cpu/timelapse-multicore-usage/timelapse-multicore-usage.component.ts
@@ -22,7 +22,6 @@ export class TimelapseMulticoreUsageComponent {
   @Input() core_count_ready_event!: Observable<number>;
   @Input() core_count!: number;
 
-  public socket!: WebSocket;
   public cores_data:number[][] = [];
 
   x_scale = 1.5;
@@ -52,8 +51,6 @@ export class TimelapseMulticoreUsageComponent {
         })
       })
     }
-  }
-  ngAfterViewInit(){
   }
 
   ngOnDestroy() {

--- a/src/app/page/memory/memory.component.html
+++ b/src/app/page/memory/memory.component.html
@@ -4,19 +4,16 @@
             <h1>{{'Memory.Memory'| translate}}</h1>
         </div>
         <!-- <span *ngIf="current_chart_type=='timelapse'">% Utilization over the last 60 seconds</span> -->
-        <app-timelapse-memory-usage
-            [total_memory]="this.total_memory"
-            [mem_info_ready_observable] = "this.memory_info_ready_subject.asObservable()"
+        <app-timelapse-memory-usage *ngIf="this.memInfo"
+            [total_memory]="this.memInfo.total"
         ></app-timelapse-memory-usage>
 
         <div class="d-flex flex-row justify-content-evenly mt-5">
-            <app-current-memory-usage class="card px-4 py-3"
-                [total_memory]="this.total_memory"
-                [mem_info_ready_observable] = "this.memory_info_ready_subject.asObservable()"
+            <app-current-memory-usage class="card px-4 py-3" *ngIf="this.memInfo"
+                [total_memory]="this.memInfo.total"
             ></app-current-memory-usage>
-            <app-current-swap-usage class="card px-4 py-3"
-                [mem_info_ready_observable]="this.memory_info_ready_subject.asObservable()"
-                [total_swap]="total_swap"
+            <app-current-swap-usage class="card px-4 py-3" *ngIf="this.memInfo"
+                [total_swap]="this.memInfo.total_swap"
             ></app-current-swap-usage>
         </div>
         

--- a/src/app/page/memory/memory.component.ts
+++ b/src/app/page/memory/memory.component.ts
@@ -22,12 +22,8 @@ import { TranslateModule } from '@ngx-translate/core';
   ]
 })
 export class MemoryComponent {
-  public memory_info_ready_subject: Subject<MemoryInfo> = new Subject<MemoryInfo>();
-  public memInfo!: MemoryInfo;
-  public total_memory!: number;
-  public total_swap!: number;
 
-  public current_chart_type: 'current' | 'timelapse' = 'timelapse';
+  public memInfo!: MemoryInfo;
 
   ngOnInit(){
     this.get_memory_information();
@@ -36,14 +32,7 @@ export class MemoryComponent {
   get_memory_information(): void {
     invoke<MemoryInfo>("get_memory_information", {}).then((res) => {
       this.memInfo = res as MemoryInfo;
-      this.total_memory = this.memInfo.total;
-      this.total_swap = this.memInfo.total_swap;
-      this.memory_info_ready_subject.next(this.memInfo);
     });
-  }
-
-  set_current_chart_type(chart_type: 'current' | 'timelapse'){
-    this.current_chart_type = chart_type;
   }
 
 }

--- a/src/app/page/processes/processes.component.ts
+++ b/src/app/page/processes/processes.component.ts
@@ -52,7 +52,7 @@ export class ProcessesComponent {
 
   private update_ui(value: ProcessInformation[]){
     this.ngZone.run(() => {
-      if(this.order_by == 'name'){
+      if(this.order_by == 'process_name'){
         value.sort(this.compare_by_name);
       }else if(this.order_by == 'parent_pid'){
         value.sort(this.compare_by_parent_pid);

--- a/src/app/page/processes/processes.component.ts
+++ b/src/app/page/processes/processes.component.ts
@@ -1,7 +1,9 @@
 import { CommonModule } from '@angular/common';
-import { Component } from '@angular/core';
+import { Component, NgZone } from '@angular/core';
 import { Router } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
+import { invoke } from '@tauri-apps/api';
+import { UnlistenFn, listen } from '@tauri-apps/api/event';
 import { AppComponent } from 'src/app/app.component';
 import { ProcessInformation, ProcessesOrderBy } from 'src/app/types/process';
 
@@ -13,86 +15,110 @@ import { ProcessInformation, ProcessesOrderBy } from 'src/app/types/process';
   imports: [CommonModule, TranslateModule]
 })
 export class ProcessesComponent {
-  socket!: WebSocket;
-
   public processes: ProcessInformation[] = [];
 
   public order_by: string = "pid";//order by process (struct/type) attribute
-  public order_by_: ProcessesOrderBy = 'pid';
   public order_desc: boolean = true;//order descending if true
 
   public memory_selected_unit: string = "MiB";
 
   constructor(
+    private ngZone: NgZone,
     private router: Router
   ){}
 
+  private unlisten_update_event!: UnlistenFn;
+
   ngOnInit(){
-    this.socket = new WebSocket("ws://127.0.0.1:9001");
-
-    this.socket.onopen = () => {
-      this.socket.send(AppComponent.app_session_id);
-      this.socket.send("current_running_processes");
-      this.socket.send(this.order_by);
-    }
-
-    this.socket.onmessage = (event) => {
-      let value = JSON.parse(event.data) as ProcessInformation[];
-      if(this.order_desc){
-        value = value.reverse();
-      }
-      this.processes = value;
-      this.socket.send(this.order_by);
-    }
+    invoke<any>('emit_current_running_processes', {orderBy: this.order_by}).then(async () => {
+      this.unlisten_update_event = await listen('current_running_processes', (event) => {
+        this.update_ui(event.payload as ProcessInformation[])
+      }) 
+    })
   }
 
   ngOnDestroy(){
-    this.socket.close();
+    this.unlisten_update_event();
+    invoke<any>('stop_current_running_processes');
   }
 
-
-  set_order_by(order_by: ProcessesOrderBy){
+  async set_order_by(order_by: ProcessesOrderBy){
     if(this.order_by == order_by){
       this.order_desc = !this.order_desc;
+      return;
     }
     this.order_by = order_by;
   }
 
-  order_by_name(){
-    if(this.order_by = 'name'){
-      this.order_desc = !this.order_desc;
-    }
-    this.order_by = 'name'
+  private update_ui(value: ProcessInformation[]){
+    this.ngZone.run(() => {
+      if(this.order_by == 'name'){
+        value.sort(this.compare_by_name);
+      }else if(this.order_by == 'parent_pid'){
+        value.sort(this.compare_by_parent_pid);
+      }else if(this.order_by == 'cpu_usage'){
+        value.sort(this.compare_by_cpu_usage);
+      }else if(this.order_by == 'memory_usage'){
+        value.sort(this.compare_by_mem_usage)
+      }
+
+      if(this.order_desc){
+        value = value.reverse();
+      }
+      this.processes = value;
+    })
   }
 
-  order_by_pid(){
-    if(this.order_by === "pid"){
-      this.order_desc = !this.order_desc;
-      return;
+  compare_by_name(a:ProcessInformation, b:ProcessInformation): number {
+    if (a.name < b.name) {
+      return -1;
+    } else if (a.name > b.name) {
+      return 1;
     }
-    this.order_by = "pid";
+    return 0;
   }
-  order_by_parent_pid(){
-    if(this.order_by === "parent_pid"){
-      this.order_desc = !this.order_desc;
-      return;
+
+  compare_by_parent_pid(a:ProcessInformation, b:ProcessInformation):number {
+    if(!a.parent_pid && !b.parent_pid){
+      return 0;
     }
-    this.order_by = "parent_pid";
-  }
-  order_by_cpu_usage(){
-    if(this.order_by === "cpu_usage"){
-      this.order_desc = !this.order_desc;
-      return;
+    if(!a.parent_pid && b.parent_pid){
+      return -1;
     }
-    this.order_by = "cpu_usage";
-  }
-  order_by_memory_usage(){
-    if(this.order_by === "memory_usage"){
-      this.order_desc = !this.order_desc;
-      return;
+    if(a.parent_pid && !b.parent_pid){
+      return 1;
     }
-    this.order_by = "memory_usage";
+    if(a.parent_pid && b.parent_pid){
+      if (a.parent_pid < b.parent_pid) {
+        return -1;
+      } else if (a.parent_pid > b.parent_pid) {
+        return 1;
+      }
+    }
+    return 0;
   }
+
+  compare_by_cpu_usage(a:ProcessInformation, b:ProcessInformation):number {
+    if(a.cpu_usage < b.cpu_usage){
+      return -1;
+    }
+    if(a.cpu_usage > b.cpu_usage){
+      return 1;
+    }
+    return 0;
+  }
+
+  compare_by_mem_usage(a:ProcessInformation, b:ProcessInformation):number {
+    if(a.memory_usage < b.memory_usage){
+      return -1;
+    }
+    if(a.memory_usage > b.memory_usage){
+      return 1;
+    }
+    return 0;
+  }
+  
+  
 
   bytes_to_byte(bytes: number): number{
     return bytes;

--- a/src/app/types/cpu-types.ts
+++ b/src/app/types/cpu-types.ts
@@ -20,6 +20,10 @@ export interface SystemStateInfo{
     os_version: string | null
 }
 
+export interface CoreBuffer{
+    buffer: number[]
+}
+
 export interface CpuPreferences{
     version: number,
     general: {

--- a/src/app/types/memory-types.ts
+++ b/src/app/types/memory-types.ts
@@ -3,6 +3,10 @@ export interface MemoryInfo{
     total_swap: number
 }
 
+export interface MemBuffer{
+    buffer: number[]
+}
+
 export interface MemoryPreferences{
     version: number,
     general: {},

--- a/src/app/types/process.ts
+++ b/src/app/types/process.ts
@@ -28,6 +28,11 @@ export interface ProcessHistory{
     disk_write_usage: number[],
 }
 
+export interface ProcessHistPayload{
+    status: boolean,
+    data: ProcessHistory
+}
+
 export interface ProcessPreferences{
     version: number,
     cpu_usage_chart:{
@@ -47,4 +52,9 @@ export interface ProcessPreferences{
         write_line_chart_color: string
         background_color: string,
     }
+}
+
+export interface ProcessInfoPayload{
+    status: boolean,
+    data: ProcessInformation
 }


### PR DESCRIPTION
The app no longer needs to spawn webserver to stream data from the back to the front. Tauri events were used, frontend components can subscribe to specific events to start listening to a stream of data.