### PR TITLE
feat: add brazilian portuguese translations for i18n

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -23,7 +23,8 @@ export class AppComponent {
 
   supported_languages = [
     {language: 'English', abbreviation: 'en'},
-    {language: 'Español', abbreviation: 'es'}
+    {language: 'Español', abbreviation: 'es'},
+    {language: 'Português', abbreviation: 'ptBr'}
   ]
 
   

--- a/src/assets/i18n/ptBr.json
+++ b/src/assets/i18n/ptBr.json
@@ -1,0 +1,121 @@
+{
+    "app":{
+        "light_mode": "Modo Claro",
+        "dark_mode": "Modo Escuro",
+        "Auto": "Auto",
+        "Language_settings": "Configuração de idiomas",
+        "Cancel": "Cancelar",
+        "Close": "Fechar"
+    },
+    "pages": {
+        "cpu": "CPU",
+        "memory": "MEMÓRIA",
+        "storage": "ARMAZENAMENTO",
+        "processes": "PROCESSOS"
+    },
+    "cpu":{
+        "CPU": "CPU",
+        "Brand":"Modelo",
+        "Vendor": "Fabricante",
+        "Max_frequency": "Freq. máxima",
+        "Cores": "Núcleos",
+        "Logical_processors": "Processadores lógicos",
+        "Utilization_over_60_seconds": "Utilização durante 60 segundos",
+        "Current_utilization": "Utilização atual",
+        "Current": "Atual",
+        "Last_minute": "Último minuto",
+        "Processor_details": "Detalhes do processador",
+        "Frequency": "Frequência",
+        "System_information": "Informação do sistema",
+        "Running_processes": "Processos em execução",
+        "Up_time": "Tempo excedido",
+        "AVG_load_1min": "Carga média (1 min)",
+        "Boot_time": "Tempo de inicialização",
+        "OS_version": "Versão do SO"
+    },
+    "current_multicore_usage":{
+        "appearance_setting": {
+            "Chart_appearance": "Aparência do gráfico",
+            "Bars_color": "Cores das barras",
+            "Background": "Fundo",
+            "Cancel": "Cancelar",
+            "Apply_changes": "Aplicar alterações"
+        }
+    },
+    "current_singlecore_usage": {
+        "AVG_utilization": "Uso médio"
+    },
+    "timelapse_multicore_usage": {
+        "appearance_setting":{
+            "Chart_appearance": "Aparência do gráfico",
+            "Lines_color": "Cor das linhas",
+            "X_axis": "eixo X",
+            "Y_axis": "eixo Y",
+            "Cancel": "Cancelar",
+            "Apply_changes": "Aplicar alterações"
+        }
+    },
+    "Memory": {
+        "Memory": "Memória"
+    },
+    "current_memory_usage": {
+        "Memory": "Memória",
+        "used_of": "usado de"
+    },
+    "current_swap_usage":{
+        "Swap": "Swap",
+        "used_of": "usado de"
+    },
+    "timelapse_memory_usage":{
+        "Utilization_over_60_seconds": "Utilização durante 60 segundos",
+        "appearance_setting":  {
+            "Chart_appearance": "Aparência do gráfico",
+            "Line_color": "Cor das linhas",
+            "Background": "Fundo",
+            "Cancel": "Cancelar",
+            "Apply_changes": "Aplicar alterações"
+        }
+    },
+    "Disks": {
+        "Storage": "Armazenamento",
+        "Disk": "Disco",
+        "used_of": "usado de",
+        "Mount_point": "Ponto de montagem",
+        "File_system": "Sistema de arquivos",
+        "Type": "Tipo",
+        "Removable": "Removível",
+        "Not_removable": "Não removível"
+    },
+    "Disk": {
+        "Disk": "Disco",
+        "Back": "Voltar",
+        "Information": "Informação",
+        "Total_space": "Espaço total",
+        "Available_space": "Espaço disponível",
+        "Used_space": "Espaço usado",
+        "Mount_point": "Ponto de montagem",
+        "File_system": "Sistema de arquivos",
+        "Type": "Tipo",
+        "Removable": "Removível",
+        "removable_yes": "Sim",
+        "removable_no": "Não",
+        "available": "disponível",
+        "used": "usado",
+        "Usage": "Uso",
+        "Used_space_composition": "Composição do espaço usado"
+    },
+    "treemap":{
+        "treeview": {
+            "Copy_path": "Copiar caminho para a área de transferência",
+            "Highlight_in_treemap": "Destaque no mapa de árvore"
+        }
+    },
+    "Processes":{
+        "Processes": "Processos",
+        "Name": "Nome",
+        "PID": "PID",
+        "Parent_PID": "PID pai",
+        "CPU_usage": "Uso de CPU",
+        "Memory_usage": "Uso de memória"
+    }
+}


### PR DESCRIPTION
Hello,

I have created a fork based on the existing project that includes the i18n library, and I have added the dictionary file for Brazilian Portuguese (pt-BR) translations. This will help in making the application accessible to Portuguese-speaking users, enhancing the overall user experience for this demographic.

Changes Made:

Added ptBr.json file to the directory with the Brazilian Portuguese translations.
Updated the i18n configuration to include the new language option.
Please review the changes and let me know if there are any adjustments needed. I believe this addition will be beneficial for users who prefer or require Portuguese as their language of interface.

Thank you for considering my contribution!